### PR TITLE
rpm: Add missing build requirement libffi-devel

### DIFF
--- a/js/rpm/SPECS/js.spec
+++ b/js/rpm/SPECS/js.spec
@@ -39,6 +39,7 @@ BuildRequires:	python
 BuildRequires:	zip
 BuildRequires:	ncurses-devel
 BuildRequires:	autoconf213
+BuildRequires:	libffi-devel
 
 
 %description


### PR DESCRIPTION
The libffi files are needed to compile js on CentOS 7.