### PR TITLE
rpm: Add missing build requirement perl

### DIFF
--- a/js/rpm/SPECS/js.spec
+++ b/js/rpm/SPECS/js.spec
@@ -36,6 +36,7 @@ Conflicts:	js <= 1.8.5
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root
 Buildrequires:	nspr-devel >= 4.7
 BuildRequires:	python
+BuildRequires:	perl
 BuildRequires:	zip
 BuildRequires:	ncurses-devel
 BuildRequires:	autoconf213


### PR DESCRIPTION
The perl interpreter is needed to compile js on Fedora 26 / 27 / 28.