### PR TITLE
Fix init script exit code #28

### DIFF
--- a/debian/couchdb.init
+++ b/debian/couchdb.init
@@ -157,4 +157,4 @@ case "$1" in
         exit 3
     ;;
 esac
-exit 0
+exit $?

--- a/rpm/SOURCES/couchdb.init
+++ b/rpm/SOURCES/couchdb.init
@@ -128,4 +128,4 @@ case "$1" in
         exit 3
     ;;
 esac
-exit 0
+exit $?


### PR DESCRIPTION
## Overview

Fix init script to honor result code of commands (status, etc)

## Testing recommendations

Stop couchddb.
Check that init script "status" command returns a non zero value.
Start couchdb
Check that init script "status" command returns a zero value.

## GitHub issue number

Fixes #28

## Related Pull Requests

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
