### PR TITLE
Explicitly depend on both python2 and python3

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: CouchDB Developers <dev@couchdb.apache.org>
 Standards-Version: 3.9.6
 Build-Depends: debhelper (>= 9),
                dh-exec,
+               dh-python,
                dh-systemd (>= 1.5),
                erlang-dev (>= 1:16.b.3) | esl-erlang (>= 1:16.b.3),
                nodejs (>= 6.10.1),
@@ -35,12 +36,14 @@ Depends: adduser,
          couch-libmozjs185-1.0,
          lsb-base,
          procps,
-         python,
+         ${python:Depends},
+         ${python3:Depends},
          python-requests,
+         python3-requests,
          ${misc:Depends},
          ${shlibs:Depends},
          ${misc:Depends}
-Recommends: python-progressbar
+Recommends: python-progressbar, python3-progressbar
 Replaces: couchdb-bin,
           couchdb-common
 Breaks: couchdb-bin,


### PR DESCRIPTION
Per already-committed changes in https://github.com/apache/couchdb/pull/1622 and coming changes for https://github.com/apache/couchdb/pull/1639, this is necessary to make `lintian` happy. Once apache/couchdb#1639 hits, we can remove the python debhelper and only require python3.