### PR TITLE
Add aarch64-debian-stretch platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,16 @@ branches:
 
 env:
   global:
-    - ERLANGVER=19.3.6
-    - TARBALL_URL=https://dist.apache.org/repos/dist/release/couchdb/source/2.3.0/apache-couchdb-2.3.0.tar.gz
-    - TARBALL=apache-couchdb-2.3.0.tar.gz
+    - ERLANGVERSION=19.3.6
+    - TARBALL_URL=https://dist.apache.org/repos/dist/release/couchdb/source/2.3.1/apache-couchdb-2.3.1.tar.gz
+    - TARBALL=apache-couchdb-2.3.1.tar.gz
   matrix:
     - TARGET="js debian-jessie"
     - TARGET="couch debian-jessie ${TARBALL_URL}"
     - TARGET="js debian-stretch"
     - TARGET="couch debian-stretch ${TARBALL_URL}"
-    - TARGET="js ubuntu-trusty"
-    - TARGET="couch ubuntu-trusty ${TARBALL_URL}"
+    - ERLANGVERSION=20.3.8.20 TARGET="js aarch64-debian-stretch"
+    - ERLANGVERSION=20.3.8.20 TARGET="couch aarch64-debian-stretch ${TARBALL_URL}"
     - TARGET="js ubuntu-xenial"
     - TARGET="couch ubuntu-xenial ${TARBALL_URL}"
     - TARGET="js ubuntu-bionic"
@@ -33,9 +33,10 @@ env:
 
 before_install:
   - docker --version
+  - docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
 script:
-  - ./build.sh ${TARGET}
+  - ERLANGVERSION=${ERLANGVERSION} ./build.sh ${TARGET}
 
 after_script:
   - ls -laR pkgs/

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ endif
 
 # Debian default
 debian: find-couch-dist copy-debian update-changelog dpkg lintian copy-pkgs
+debian-no-lintian: find-couch-dist copy-debian update-changelog dpkg copy-pkgs
 
 # Debian 8
 debian-jessie: PLATFORM=jessie
@@ -41,7 +42,13 @@ jessie: debian
 debian-stretch: PLATFORM=stretch
 debian-stretch: DIST=debian-stretch
 debian-stretch: stretch
+# AArch64 Debian 9
+# Lintian doesn't install correctly into a cross-built Docker container ?!
+aarch64-debian-stretch: PLATFORM=stretch
+aarch64-debian-stretch: DIST=debian-stretch
+aarch64-debian-stretch: debian-no-lintian
 stretch: debian
+
 
 # Ubuntu 12.04
 ubuntu-precise: PLATFORM=precise

--- a/build.sh
+++ b/build.sh
@@ -29,9 +29,9 @@ SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # TODO derive these by interrogating the Docker repo rather tha
 # hard coding the list
-DEBIANS="debian-jessie debian-stretch"
+DEBIANS="debian-jessie debian-stretch aarch64-debian-stretch"
 UBUNTUS="ubuntu-trusty ubuntu-xenial ubuntu-bionic"
-debs="(debian-jessie|debian-stretch|ubuntu-trusty|ubuntu-xenial|ubuntu-bionic)"
+debs="(debian-jessie|debian-stretch|aarch64-debian-stretch|ubuntu-trusty|ubuntu-xenial|ubuntu-bionic)"
 
 CENTOSES="centos-6 centos-7"
 rpms="(centos-6|centos-7)"
@@ -43,10 +43,17 @@ ERLANGVERSION=${ERLANGVERSION:-19.3.6}
 build-js() {
   # TODO: check if image is built first, if not, complain
   # invoke as build-js <plat>
-  docker run \
-      --mount type=bind,src=${SCRIPTPATH},dst=/home/jenkins/couchdb-pkg \
-      couchdbdev/$1-base \
-      sudo /home/jenkins/couchdb-pkg/bin/build-js.sh
+  if [[ ${TRAVIS} == "true" ]]; then
+    docker run \
+        --mount type=bind,src=${SCRIPTPATH},dst=/home/jenkins/couchdb-pkg \
+        -u 0 couchdbdev/$1-base \
+        /home/jenkins/couchdb-pkg/bin/build-js.sh
+  else
+    docker run \
+        --mount type=bind,src=${SCRIPTPATH},dst=/home/jenkins/couchdb-pkg \
+        couchdbdev/$1-base \
+        sudo /home/jenkins/couchdb-pkg/bin/build-js.sh
+  fi
 }
 
 build-all-js() {


### PR DESCRIPTION
## Overview

Adds the new `aarch64` platform image for package building purposes.

Closes #43 (for Debian, anyway, which is what we target with our Docker images)

## Testing recommendations

```
./build.sh js aarch64-debian-stretch
./build.sh couch aarch64-debian-stretch https://dist.apache.org/repos/dist/release/couchdb/source/2.3.1/apache-couchdb-2.3.1.tar.gz
```