### PR TITLE
fix etc/default.d/* ownership

### DIFF
--- a/debian/couchdb.postinst
+++ b/debian/couchdb.postinst
@@ -187,16 +187,22 @@ case $1 in
     esac
 
     # These should be owned by the couchdb user and group:
-    chown couchdb:couchdb /opt/couchdb/etc
-    chown couchdb:couchdb /opt/couchdb/etc/* >/dev/null 2>&1 || true
-    chown couchdb:couchdb /var/lib/couchdb
-    chown couchdb:couchdb /var/lib/couchdb/* >/dev/null 2>&1 || true
-    chown couchdb:couchdb /var/lib/couchdb/shards/* >/dev/null 2>&1 || true
-    chown couchdb:couchdb /var/lib/couchdb/shards/*/* >/dev/null 2>&1 || true
-    chown couchdb:couchdb /var/lib/couchdb/.shards/* >/dev/null 2>&1 || true
-    chown couchdb:couchdb /var/lib/couchdb/.shards/*/* >/dev/null 2>&1 || true
-    chown couchdb:couchdb /var/log/couchdb
-    chown couchdb:couchdb /var/log/couchdb/* >/dev/null 2>&1 || true
+    for i in "/opt/couchdb/etc
+      /opt/couchdb/etc/*
+      /opt/couchdb/etc/default.d/*
+      /opt/couchdb/etc/local.d/*
+      /var/lib/couchdb
+      /var/lib/couchdb/*
+      /var/lib/couchdb/shards/*
+      /var/lib/couchdb/shards/*/*
+      /var/lib/couchdb/.shards/*
+      /var/lib/couchdb/.shards/*/*
+      /var/log/couchdb
+      /var/log/couchdb/*"
+    do
+      chown couchdb:couchdb $i >/dev/null 2>&1 || true
+    done
+      
     # These should also not be world readable or writable:
     find /opt/couchdb/etc -name *.ini -exec chmod 0640 {} \;
     chmod a+x /opt/couchdb/bin/couchup


### PR DESCRIPTION
Omission of `etc/default.d` in `couchdb.postinst` caused the `etc/default.d/*` files to be unreadable to the couchdb process. 

Closes #47.
