### PR TITLE
Add extra protection to databases during package purge

### DIFF
--- a/debian/couchdb.postrm
+++ b/debian/couchdb.postrm
@@ -19,21 +19,36 @@ case $1 in
         if test -d "/opt/couchdb/etc"; then
             rm -rf "/opt/couchdb/etc"
         fi
-        if test -d "/var/lib/couchdb"; then
-            rm -rf "/var/lib/couchdb"
-        fi
         if test -d "/var/log/couchdb"; then
             rm -rf "/var/log/couchdb"
         fi
+
+        db_input high couchdb/postrm_remove_databases || true
+        db_go || true
+        db_get couchdb/postrm_remove_databases || true
+
+        if [ "$RET" = "true" ]; then
+            if test -d "/var/lib/couchdb"; then
+                rm -rf "/var/lib/couchdb"
+            fi
+
+            # If we didn't delete the data, we should
+            # keep the uid and gid too.
+            if getent passwd couchdb > /dev/null; then
+                deluser couchdb >/dev/null 2>&1
+            fi
+            if getent group couchdb > /dev/null; then
+                delgroup couchdb >/dev/null 2>&1
+            fi
+
+            # The node name is embedded in the _dbs
+            # documents, so we must not reset it if
+            # we preserved the data.
+            db_reset couchdb/nodename
+        fi
+
         pkill -u couchdb >/dev/null 2>&1 || true
-        if getent passwd couchdb > /dev/null; then
-            deluser couchdb >/dev/null 2>&1
-        fi
-        if getent group couchdb > /dev/null; then
-            delgroup couchdb >/dev/null 2>&1
-        fi
         db_reset couchdb/mode
-        db_reset couchdb/nodename
         db_reset couchdb/cookie
         db_reset couchdb/adminpass
         db_reset couchdb/adminpass_again

--- a/debian/couchdb.templates
+++ b/debian/couchdb.templates
@@ -94,3 +94,11 @@ _Description: CouchDB 1.x databases found
  /var/lib/couchdb directory. These need migration to be used in
  CouchDB 2.x and forward. Use the `couchup' utility to assist in
  the migration process.
+
+Template: couchdb/postrm_remove_databases
+Type: boolean
+Default: false
+_Description: Remove all CouchDB databases?
+ The /var/lib/couchdb directory containing all CouchDB databases will
+ be removed. This will also clear the stored node name for this machine,
+ and remove the couchdb user and group.


### PR DESCRIPTION
## Overview

Using `apt-get --purge` removes all CouchDB databases. This is surprising as `--purge` is
defined as removing config files. Other database packages (like mysql) have an additional
debconf property for data destruction beyond config files. This PR follows the mysql package
in adding that property and defaulting it to false. This allows a purge with complete data removal if desired.

## Testing recommendations

Install CouchDB, create databases, then purge the package. The .couch files should remain
in `/var/lib/couchdb`. 

## GitHub issue number

N/A

## Related Pull Requests

N/A

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
