### PR TITLE
Core18 env

### DIFF
--- a/README-SNAP.md
+++ b/README-SNAP.md
@@ -61,10 +61,34 @@ $ sudo snap restart couchdb
 
 ## Monitoring CouchDB 
 
-The logs, by default, are captured by journald. View the logs with:
+The logs, by default, are captured by journald. View the logs with either command:
 
 ```bash
-$ journalctl -u snap.couchdb* -f`
+$ snap logs couchdb -f
+$ journalctl -u snap.couchdb* -f
+```
+
+## Removing CouchDB
+
+There are several difference between installation via 'apt' and 'snap'. One important 
+difference is when removing couchdb. When calling 'apt remove couchdb', the binaries 
+are removed but the configuration and the couch database files remain, leaving the 
+user to clean up any databases latter. 
+
+Calling 'snap remove couchdb' *will* remove binaries, configurations and the database.
+
+On newer versions of snapd (snapd 2.39+) a snapshot is made of the SNAP_DATA 
+and SNAP_COMMON directories and this is stored (subject to disc space) for about 30 days. 
+On these newer version a 'snap remove' followed by a 'snap install' may restore the 
+database; but you are best to make your own backup before removing couchdb.
+If you do not want to keep the configuration or database files you can delete the 
+snapshot by calling snap remove with the --purge parameter. 
+
+To remove your installation either:
+
+```bash
+$ sudo snap remove couchdb
+$ sudo snap remove couchdb --purge
 ```
 
 -----
@@ -89,7 +113,7 @@ couchdb-c1> apt update
 couchdb-c1> snap install couchdb --edge
 couchdb-c1> snap connect couchdb:mount-observe
 couchdb-c1> snap connect couchdb:process-control
-couchdb-c1> curl -X PUT http://localhost:5984/_node/_local/_config/httpd/bind_address -d '"0.0.0.0"'
+couchdb-c1> curl -X PUT http://localhost:5984/_node/_local/_config/chttpd/bind_address -d '"0.0.0.0"'
 couchdb-c1> curl -X PUT http://localhost:5984/_node/_local/_config/admins/admin -d '"Be1stDB"'
 couchdb-c1> exit
 ```

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -12,15 +12,11 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-mkdir -p ${SNAP_COMMON}/data
+# If the data directory does not exisit in /var/couchdb/common; but does exisit in /var/couchdb/current; move it to common.
 
-mkdir -p ${SNAP_DATA}/etc/local.d
-
-if [ ! -s ${SNAP_DATA}/etc/vm.args ]; then
-   cat ${SNAP}/opt/couchdb/etc/vm.args.dist > ${SNAP_DATA}/etc/vm.args
-fi
-
-if [ ! -s ${SNAP_DATA}/etc/local.ini ]; then
-   cat ${SNAP}/opt/couchdb/etc/local.ini.dist > ${SNAP_DATA}/etc/local.ini
+if [ ! -d ${SNAP_COMMON}/data ]; then
+   if [ -d ${SNAP_DATA}/data ]; then
+       mv ${SNAP_DATA}/data ${SNAP_COMMON}/data
+   fi
 fi
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -82,9 +82,9 @@ parts:
 layout:
   # Database and log files are common across upgrades
   $SNAP/opt/couchdb/data:
-    bind: $SNAP_DATA/data
+    bind: $SNAP_COMMON/data
   $SNAP/opt/couchdb/var/log:
-    bind: $SNAP_DATA/log
+    bind: $SNAP_COMMON/log
   # Local configuration files may change across upgrades
   $SNAP/opt/couchdb/etc/vm.args:
     bind-file: $SNAP_DATA/etc/vm.args
@@ -93,6 +93,10 @@ layout:
   $SNAP/opt/couchdb/etc/local.ini:
     bind-file: $SNAP_DATA/etc/local.ini
   # We do not bind default.ini or default.d/ as these are intended to be immutable
+  
+environment:
+  COUCHDB_ARGS_FILE: ${SNAP_DATA}/etc/vm.args
+  ERL_FLAGS: "-couch_ini ${SNAP}/opt/couchdb/etc/default.ini ${SNAP}/opt/couchdb/etc/default.d ${SNAP_DATA}/etc/local.ini ${SNAP_DATA}/etc/local.d"
 
 apps:
   couchdb:
@@ -106,7 +110,10 @@ apps:
     plugs: [network, network-bind, process-control, mount-observe]
   remsh:
     command: opt/couchdb/bin/remsh
-    plugs: [network, network-bind, process-control]
+    plugs: [network, network-bind]
   couchup:
     command: opt/couchdb/bin/couchup
-    plugs: [network, network-bind, process-control]
+    plugs: [network, network-bind]
+  couchjs:
+    command: opt/couchdb/bin/couchjs
+    plugs: [network, network-bind]


### PR DESCRIPTION
## Overview

For the installation I used the snap store snapcraft (snap install snapcraft --classic) 

1. ./data now points to SNAP_COMMON and I have added a pre-refresh hook that (should) migrate user's data directory from SNAP_DATA to SNAP_COMMON. (this may require the snapcraft version from the snap store)

2. Added a (temporary) environment block. vm.args and local.ini are ignored without explicitly setting the environment variables. The (recent) layout feature in snapcraft uses mount --bind and I suspect it is the relative directory in ROOTDIR (/opt/couch/bin/../etc/ redirection) which is causing the problem; (this would need changing in the bin/couch file). I also changed the install hook from 'cp' to 'cat', to avoid any possible clobbering of the ionode (although it seems this is not root cause). This is a work around and the environment block can be removed once the layout block is working. 

3. Removed process-control from remsh and couchup (unneeded security risk)

4. Added /snap/bin/couchdb.couchjs (useful for syntax checking design doc views and scripts)

5. Added a section to the README-SNAP.md about the differences between apt and snap when removing binaries.

## Testing recommendations

I have tested this on the beta branch of my snap store.
```sudo snap refresh --channel=beta couchdb-sklassen```

## GitHub issue number

Continued work on issue Number #48 

