### PR TITLE
rpm: Support Fedora 31+ and CentOS 8+

### DIFF
--- a/js/rpm/SPECS/js.spec
+++ b/js/rpm/SPECS/js.spec
@@ -39,7 +39,7 @@ Buildrequires:	mozilla-nspr-devel >= 4.7
 BuildRequires:	python3
 %else
 Buildrequires:	nspr-devel >= 4.7
-BuildRequires:	python
+BuildRequires:	python2
 %endif
 BuildRequires:	perl
 BuildRequires:	zip


### PR DESCRIPTION
Fedora 31 was released this month, and CentOS 8 last week. Since this
releases, `python` doesn't implicitly mean `python2` anymore (and on
Fedora 31, Python is Python 3 by default).

Hence, the `BuildRequires` entry must be more precise, otherwise
`./configure` fails with:

    checking for Python version >= 2.5 but not 3.x... configure: error: Python 2.5 or higher (but not Python 3.x) is required.

or on CentOS 8:

    No matching package to install: 'python'

Related to: https://github.com/adrienverge/copr-couchdb/issues/8
