### PR TITLE
Improve multi-platform package building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ PKGDIR=$(COUCHDIR)
 
 ifeq ($(shell arch),aarch64)
 PKGARCH=arm64
+else ifeq ($(shell arch),arm64v8)
+PKGARCH=arm64
 else
 PKGARCH=$(shell arch)
 endif
@@ -44,9 +46,13 @@ debian-stretch: DIST=debian-stretch
 debian-stretch: stretch
 # AArch64 Debian 9
 # Lintian doesn't install correctly into a cross-built Docker container ?!
+arm64v8-debian-stretch: aarch64-debian-stretch
 aarch64-debian-stretch: PLATFORM=stretch
 aarch64-debian-stretch: DIST=debian-stretch
 aarch64-debian-stretch: debian-no-lintian
+ppc64le-debian-stretch: PLATFORM=stretch
+ppc64le-debian-stretch: DIST=debian-stretch
+ppc64le-debian-stretch: stretch
 stretch: debian
 
 # Debian 10
@@ -54,6 +60,7 @@ debian-buster: PLATFORM=buster
 debian-buster: DIST=debian-buster
 debian-buster: buster
 # Lintian doesn't install correctly into a cross-built Docker container ?!
+arm64v8-debian-buster: aarch64v8-debian-buster
 aarch64-debian-buster: PLATFORM=buster
 aarch64-debian-buster: DIST=debian-buster
 aarch64-debian-buster: debian-no-lintian
@@ -110,12 +117,16 @@ centos-7: DIST=centos-7
 centos-7: centos7
 centos7: make-rpmbuild centos
 
+centos-8: DIST=centos-8
+centos-8: centos8
+centos8: make-rpmbuild centos
+
 openSUSE: centos7
 
 # Erlang is built from source on ARMv8
 # These packages are not installed, but the files are present
 drop-deb-deps-for-source-arch:
-	if [ "$(shell arch)" = "aarch64" ]; then                          \
+	if [ "$(shell arch)" != "x86_64" ]; then                          \
 		sed -i '/erlang-dev/d' $(DISTDIR)/debian/control;         \
 		sed -i '/erlang-crypto/d' $(DISTDIR)/debian/control;      \
 		sed -i '/erlang-dialyzer/d' $(DISTDIR)/debian/control;    \

--- a/rpm/SPECS/couchdb.spec
+++ b/rpm/SPECS/couchdb.spec
@@ -48,7 +48,6 @@ Requires(post): python3-requests
 BuildRequires: esl-erlang
 BuildRequires: gcc
 Requires(pre): shadow-utils
-BuildRequires: python >= 2.6
 #BuildRequires: python-pip
 #BuildRequires: python-sphinx >= 1.5.3
 Requires(post): python-progressbar


### PR DESCRIPTION
## Overview

Minor changes necessary to simplify building ppc64le and aarch64 packages, as well as CentOS 8 packages.

## Testing recommendations

If you have one of those alternative architectures, try using the scripts to build js or couch packages.

## Checklist

- [X] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [X] Documentation reflects the changes;
