### PR TITLE
Minor cleanup for better multiarch support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ debian-buster: PLATFORM=buster
 debian-buster: DIST=debian-buster
 debian-buster: buster
 # Lintian doesn't install correctly into a cross-built Docker container ?!
-arm64v8-debian-buster: aarch64v8-debian-buster
+arm64v8-debian-buster: aarch64-debian-buster
 aarch64-debian-buster: PLATFORM=buster
 aarch64-debian-buster: DIST=debian-buster
 aarch64-debian-buster: debian-no-lintian
@@ -123,21 +123,6 @@ centos8: make-rpmbuild centos
 
 openSUSE: centos7
 
-# Erlang is built from source on ARMv8
-# These packages are not installed, but the files are present
-drop-deb-deps-for-source-arch:
-	if [ "$(shell arch)" != "x86_64" ]; then                          \
-		sed -i '/erlang-dev/d' $(DISTDIR)/debian/control;         \
-		sed -i '/erlang-crypto/d' $(DISTDIR)/debian/control;      \
-		sed -i '/erlang-dialyzer/d' $(DISTDIR)/debian/control;    \
-		sed -i '/erlang-eunit/d' $(DISTDIR)/debian/control;       \
-		sed -i '/erlang-inets/d' $(DISTDIR)/debian/control;       \
-		sed -i '/erlang-xmerl/d' $(DISTDIR)/debian/control;       \
-		sed -i '/erlang-os-mon/d' $(DISTDIR)/debian/control;      \
-		sed -i '/erlang-reltool/d' $(DISTDIR)/debian/control;     \
-		sed -i '/erlang-syntax-tools/d' $(DISTDIR)/debian/control;\
-	fi
-
 # ######################################
 get-couch:
 	mkdir -p $(COUCHDIR)
@@ -165,7 +150,7 @@ copy-debian:
 	rm -rf $(DISTDIR)/debian
 	cp -R debian $(DISTDIR)
 
-update-changelog: drop-deb-deps-for-source-arch
+update-changelog:
 	cd $(DISTDIR) && dch -v $(VERSION)~$(PLATFORM) $(DEBCHANGELOG)
 
 dpkg:

--- a/rpm/SPECS/couchdb.spec
+++ b/rpm/SPECS/couchdb.spec
@@ -42,16 +42,24 @@ BuildRequires: gcc-c++
 BuildRequires: pkg-config
 Requires(pre): shadow
 BuildRequires: python3
-Requires(post): python3-progressbar
-Requires(post): python3-requests
 %else
 BuildRequires: esl-erlang
 BuildRequires: gcc
 Requires(pre): shadow-utils
 #BuildRequires: python-pip
 #BuildRequires: python-sphinx >= 1.5.3
-Requires(post): python-progressbar
-Requires(post): python-requests
+%endif
+
+%if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?suse_version}
+%if 0%{?suse_version} || 0%{?fedora}
+Requires(post): python3-progressbar
+%endif
+Requires(post): python3
+Requires(post): python3-requests
+%endif
+%if 0%{?rhel} <= 7
+Requires(post): python34-requests
+Requires(post): python34
 %endif
 
 BuildRequires: git


### PR DESCRIPTION
1. 64-bit arm has been renamed `arm64v8` to match the Docker arch requirement.
2. We no longer need to remove build-time package dependencies with sed, as we install fake packages during the setup process if falling back to source install.
3. Some Python dependency packages in CentOS have changed names, this fixes that problem.