### PR TITLE
Whitelist ppc64le in the CouchDB rpm

### DIFF
--- a/rpm/SPECS/couchdb.spec
+++ b/rpm/SPECS/couchdb.spec
@@ -28,8 +28,8 @@ Prefix:        %{prefix}
 Group:         Applications/Databases
 URL:           https://couchdb.apache.org/
 Vendor:        The Apache Software Foundation
-BuildArch:     x86_64
-ExclusiveArch: x86_64
+BuildArch:     x86_64 ppc64le
+ExclusiveArch: x86_64 ppc64le
 Exclusiveos:   linux
 Packager:      CouchDB Developers <dev@couchdb.apache.org>
 
@@ -79,7 +79,7 @@ Requires(post): procps
 BuildRequires: 		systemd-rpm-macros
 %else
 BuildRequires:		xfsprogs-devel
-%endif 
+%endif
 %{?systemd_requires}
 BuildRequires:		systemd
 %else


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

The CouchDB rpm builds correctly on/for ppc64le using Centos 7. This change adds ppc64le to the whitelisted architectures in the rpm spec. I verified that I can build the rpm and necessary dependencies on POWER hardware (I've found it unreliable on an emulator).

I haven't made any changes to the Travis / CI config to build for power - as I understand it this is blocked on migration to Jenkins with POWER hardware. If there's interest before then, I can share the packages for couch js / couchdb for publication to bintray.

## Testing recommendations

On a ppc64le machine, `make centos-7 VERSION=master PLATFORM=centos-7`

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-pkg/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
