### PR TITLE
Bump default service fd limit to erlang +Q default of 65536

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ branches:
 env:
   global:
     - ERLANGVERSION=20.3.8.25-1
-    - TARBALL_URL=https://dist.apache.org/repos/dist/release/couchdb/source/3.0.0/apache-couchdb-3.0.0.tar.gz
-    - TARBALL=apache-couchdb-3.0.0.tar.gz
+    - TARBALL_URL=https://dist.apache.org/repos/dist/release/couchdb/source/3.1.0/apache-couchdb-3.1.0.tar.gz
+    - TARBALL=apache-couchdb-3.1.0.tar.gz
   matrix:
     - TARGET="js debian-stretch"
     - TARGET="couch debian-stretch ${TARBALL_URL}"

--- a/debian/couchdb.service
+++ b/debian/couchdb.service
@@ -9,6 +9,7 @@ User=couchdb
 Group=couchdb
 ExecStart=/opt/couchdb/bin/couchdb
 Restart=always
+LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target

--- a/rpm/SOURCES/couchdb.service
+++ b/rpm/SOURCES/couchdb.service
@@ -9,6 +9,7 @@ User=couchdb
 Group=couchdb
 ExecStart=/opt/couchdb/bin/couchdb
 Restart=always
+LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Overview

The Erlang CouchDB ships with now has a default number of 65536 max ports (+Q). This bumps the default limit under systemd to 65536, without requiring operator intervention to reach the new limit.

## Testing recommendations

1. Install CouchDB from the build rpm or deb package
2. Start the CouchDB service with `systemctl start couchdb`
3. Get the pid of the `beam.smp` process
4. `cat /proc/<pid>/limits` and look for the `Max open files` line, ensure the limit is now 65536.

## Related Pull Requests

Documentation PR to follow

## Checklist

- [X] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
