### PR TITLE
Update the install script ensure database location is absolute

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
 # the License at
@@ -12,15 +10,37 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-mkdir -p ${SNAP_COMMON}/data
 
-mkdir -p ${SNAP_DATA}/etc/local.d
-
-if [ ! -s ${SNAP_DATA}/etc/vm.args ]; then
-   cat ${SNAP}/opt/couchdb/etc/vm.args.dist > ${SNAP_DATA}/etc/vm.args
+if [ -z ${SNAP_INSTANCE_KEY} ]
+then
+    SNAP_INSTANCE_DATA=${SNAP_DATA}
+    SNAP_INSTANCE_COMMON=${SNAP_COMMON}
+else
+    SNAP_INSTANCE_DATA=$(echo ${SNAP_DATA} | sed -e s/${SNAP_NAME}/${SNAP_INSTANCE_NAME}/)
+    SNAP_INSTANCE_COMMON=$(echo ${SNAP_COMMON} | sed -e s/${SNAP_NAME}/${SNAP_INSTANCE_NAME}/)
 fi
 
-if [ ! -s ${SNAP_DATA}/etc/local.ini ]; then
-   cat ${SNAP}/opt/couchdb/etc/local.ini.dist > ${SNAP_DATA}/etc/local.ini
+mkdir -p ${SNAP_INSTANCE_DATA}/etc
+mkdir -p ${SNAP_INSTANCE_DATA}/etc/local.d
+mkdir -p ${SNAP_INSTANCE_COMMON}/data
+
+if [ ! -s ${SNAP_INSTANCE_DATA}/etc/vm.args ]; then
+   cat ${SNAP}/etc/vm.args > ${SNAP_INSTANCE_DATA}/etc/vm.args
 fi
 
+LOCAL_INI=$SNAP_INSTANCE_DATA/etc/local.ini
+if [ ! -s ${LOCAL_INI} ]; then
+   cat ${SNAP}/etc/local.ini > ${LOCAL_INI}
+fi
+
+# Ensure that local.ini has the view_index_dir specified
+if ! $(grep -q "^view_index_dir" ${LOCAL_INI}); then
+    view_line=$(echo "view_index_dir = ${SNAP_INSTANCE_COMMON}/data" | sed 's/\//\\\//g')
+    sed --in-place "/^\[couchdb\].*$/a ${view_line}" ${LOCAL_INI} 
+fi
+
+# Ensure that local.ini has the database_dir specified
+if ! $(grep -q "^database_dir" ${LOCAL_INI}); then
+    database_line=$(echo "database_dir = ${SNAP_INSTANCE_COMMON}/data" | sed 's/\//\\\//g')
+    sed --in-place "/^\[couchdb\].*$/a ${database_line}" ${LOCAL_INI} 
+fi


### PR DESCRIPTION
This script now ensures that the database_dir and view_index_dir are set in the local.ini
