### PR TITLE
Drop support for Ubuntu 16.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,12 +109,6 @@ ppc64le-debian-bullseye: bullseye
 bullseye: debian
 
 
-# Ubuntu 16.04 (Xenial)
-ubuntu-xenial: PLATFORM=xenial
-ubuntu-xenial: DIST=ubuntu-xenial
-ubuntu-xenial: xenial
-xenial: debian
-
 # Ubuntu 18.04 (Bionic)
 ubuntu-bionic: PLATFORM=bionic
 ubuntu-bionic: DIST=ubuntu-bionic

--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # TODO derive these by interrogating the couchdb-ci repo rather than hard coding the list
 DEBIANS="debian-stretch debian-buster debian-bullseye"
-UBUNTUS="ubuntu-xenial ubuntu-bionic ubuntu-focal"
+UBUNTUS="ubuntu-bionic ubuntu-focal"
 CENTOSES="centos-7 centos-8"
 XPLAT_BASE="debian-buster"
 XPLAT_ARCHES="arm64v8 ppc64le"


### PR DESCRIPTION
As proposed on the mailing list, removing support Ubuntu Xenial so no new releases will be packaged for it.