### PR TITLE
Drop support for Debian 9 (stretch)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,22 +43,6 @@ all:
 # Debian default
 debian: sm-ver-debian find-couch-dist copy-debian update-changelog dpkg lintian copy-pkgs
 
-# Debian 9 - stretch
-debian-stretch: PLATFORM=stretch
-debian-stretch: DIST=debian-stretch
-debian-stretch: stretch
-
-arm64v8-debian-stretch: aarch64-debian-stretch
-aarch64-debian-stretch: PLATFORM=stretch
-aarch64-debian-stretch: DIST=debian-stretch
-aarch64-debian-stretch: stretch
-
-ppc64le-debian-stretch: PLATFORM=stretch
-ppc64le-debian-stretch: DIST=debian-stretch
-ppc64le-debian-stretch: stretch
-
-stretch: debian
-
 # Debian 10 - buster
 debian-buster: PLATFORM=buster
 debian-buster: DIST=debian-buster

--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ set -e
 SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # TODO derive these by interrogating the couchdb-ci repo rather than hard coding the list
-DEBIANS="debian-stretch debian-buster debian-bullseye"
+DEBIANS="debian-buster debian-bullseye"
 UBUNTUS="ubuntu-bionic ubuntu-focal"
 CENTOSES="centos-7 centos-8"
 XPLAT_BASE="debian-bullseye"


### PR DESCRIPTION
## Overview

  Removal based on xenials removal: https://github.com/apache/couchdb-pkg/pull/88

## Testing recommendations

## GitHub issue number

## Related Pull Requests

https://github.com/apache/couchdb/pull/4006

## Checklist

- [X] Code is written and works correctly; (visual inspection only)
- [X] Changes are covered by tests;
- [X] Documentation reflects the changes;
