### PR TITLE
Improve cookie setup for RPMs

### DIFF
--- a/rpm/SPECS/couchdb.spec.in
+++ b/rpm/SPECS/couchdb.spec.in
@@ -145,18 +145,24 @@ if ! /usr/bin/getent passwd couchdb > /dev/null; then /usr/sbin/adduser \
 
 %post
 if %{__grep} -q "^-setcookie monster$" /opt/%{name}/etc/vm.args; then
-  echo "Please enter a cookie value for this installation: " >/dev/tty
-  if exec </dev/tty; then
-    read cookie;
+  # -v is a bash 4.2+ feature
+  if [[ -v COUCHDB_COOKIE ]]; then
+    echo "Using defined COUCHDB_COOKIE value."
+    cookie=${COUCHDB_COOKIE}
+  else
+    echo "Generating random cookie value."
+    cookie=$(cat /dev/random | tr -dc 'a-zA-Z0-9' | head --bytes 48)
   fi
-  echo "Writing $cookie to vm.args..."
   %{__sed} -i "s/^-setcookie monster.*$/-setcookie ${cookie}/" /opt/%{name}/etc/vm.args
 elif %{__grep} -q "^[# ]*-setcookie$" /opt/%{name}/etc/vm.args; then
-  echo "Please enter a cookie value for this installation: " >/dev/tty
-  if exec </dev/tty; then
-    read cookie;
+  # -v is a bash 4.2+ feature
+  if [[ -v COUCHDB_COOKIE ]]; then
+    echo "Using defined COUCHDB_COOKIE value."
+    cookie=${COUCHDB_COOKIE}
+  else
+    echo "Generating random cookie value."
+    cookie=$(cat /dev/random | tr -dc 'a-zA-Z0-9' | head --bytes 48)
   fi
-  echo "Writing $cookie to vm.args..."
   %{__sed} -i "s/^[# ]*-setcookie.*$/-setcookie ${cookie}/" /opt/%{name}/etc/vm.args
 fi
 %{__chown} -R couchdb:couchdb /opt/%{name}


### PR DESCRIPTION
Previously, with an embedded prompt, it was hard to automatically provision nodes.

Avoid the interactive TTY prompt by setting a random 48 character (285 bits of entropy) cookie from /dev/urandom instead. This should help automating standalone setups.

Improve clustered setups by allowing users to specify the cookie as an environment variable. In this way the cookie may be automatically provisioned on all the nodes of the cluster during the initial install.

Fixes https://github.com/apache/couchdb-pkg/issues/94
