### PR TITLE
Fix generation of random cookie value

### DIFF
--- a/rpm/SPECS/couchdb.spec.in
+++ b/rpm/SPECS/couchdb.spec.in
@@ -151,7 +151,7 @@ if %{__grep} -q "^-setcookie monster$" /opt/%{name}/etc/vm.args; then
     cookie=${COUCHDB_COOKIE}
   else
     echo "Generating random cookie value."
-    cookie=$(cat /dev/random | tr -dc 'a-zA-Z0-9' | head --bytes 48)
+    cookie=$(tr -cd [:alnum:] < /dev/urandom | head -c 48)
   fi
   %{__sed} -i "s/^-setcookie monster.*$/-setcookie ${cookie}/" /opt/%{name}/etc/vm.args
 elif %{__grep} -q "^[# ]*-setcookie$" /opt/%{name}/etc/vm.args; then
@@ -161,7 +161,7 @@ elif %{__grep} -q "^[# ]*-setcookie$" /opt/%{name}/etc/vm.args; then
     cookie=${COUCHDB_COOKIE}
   else
     echo "Generating random cookie value."
-    cookie=$(cat /dev/random | tr -dc 'a-zA-Z0-9' | head --bytes 48)
+    cookie=$(tr -cd [:alnum:] < /dev/urandom | head -c 48)
   fi
   %{__sed} -i "s/^[# ]*-setcookie.*$/-setcookie ${cookie}/" /opt/%{name}/etc/vm.args
 fi


### PR DESCRIPTION
## Overview

This pull request addresses the problem where the installation via the provided RPM package would not terminate on some systems. This is due to the choice of using `/dev/random` as the source for the generation of the random cookie value.

## Testing recommendations

This can be tested by installing the RPM package without providing the `COUCHDB_COOKIE` environment variable.

## Checklist

- [X] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
