### PR TITLE
Improve /dev/random usage when generating cookies for RPM distros

### DIFF
--- a/rpm/SPECS/couchdb.spec.in
+++ b/rpm/SPECS/couchdb.spec.in
@@ -151,7 +151,7 @@ if %{__grep} -q "^-setcookie monster$" /opt/%{name}/etc/vm.args; then
     cookie=${COUCHDB_COOKIE}
   else
     echo "Generating random cookie value."
-    cookie=$(cat /dev/random | tr -dc 'a-zA-Z0-9' | head --bytes 48)
+    cookie=$(dd if=/dev/random bs=1 count=38 status=none | base64 | tr -cd [:alnum:])
   fi
   %{__sed} -i "s/^-setcookie monster.*$/-setcookie ${cookie}/" /opt/%{name}/etc/vm.args
 elif %{__grep} -q "^[# ]*-setcookie$" /opt/%{name}/etc/vm.args; then
@@ -161,7 +161,7 @@ elif %{__grep} -q "^[# ]*-setcookie$" /opt/%{name}/etc/vm.args; then
     cookie=${COUCHDB_COOKIE}
   else
     echo "Generating random cookie value."
-    cookie=$(cat /dev/random | tr -dc 'a-zA-Z0-9' | head --bytes 48)
+    cookie=$(dd if=/dev/random bs=1 count=38 status=none | base64 | tr -cd [:alnum:])
   fi
   %{__sed} -i "s/^[# ]*-setcookie.*$/-setcookie ${cookie}/" /opt/%{name}/etc/vm.args
 fi


### PR DESCRIPTION
In a low entropy environments, `/dev/random` will block, so make sure to use only as many bytes as we'll need instead of reading and discarding bytes as we did previously.

Thanks to @lostnet for the `dd` idea and to @Inperpetuammemoriam for reporting the issue in https://github.com/apache/couchdb-pkg/pull/98