### PR TITLE
Add ubuntu jammy distro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,14 @@ ubuntu-focal: SM_VER=68
 ubuntu-focal: focal
 focal: debian
 
+# Ubuntu 22.04 (Jammy)
+ubuntu-jammy: PLATFORM=jammy
+ubuntu-jammy: DIST=ubuntu-jammy
+ubuntu-jammy: SPIDERMONKEY=libmozjs-78-0
+ubuntu-jammy: SPIDERMONKEY_DEV=libmozjs-78-dev
+ubuntu-jammy: SM_VER=78
+ubuntu-jammy: jammy
+jammy: debian
 
 # RPM default
 centos: PKGDIR=../rpmbuild/RPMS/$(PKGARCH)

--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # TODO derive these by interrogating the couchdb-ci repo rather than hard coding the list
 DEBIANS="debian-buster debian-bullseye"
-UBUNTUS="ubuntu-bionic ubuntu-focal"
+UBUNTUS="ubuntu-bionic ubuntu-focal ubuntu-jammy"
 CENTOSES="centos-7 centos-8"
 XPLAT_BASE="debian-bullseye"
 XPLAT_ARCHES="arm64 ppc64le"

--- a/repo/conf/distributions
+++ b/repo/conf/distributions
@@ -32,3 +32,8 @@ Codename: focal
 Components: main
 Architectures: amd64 arm64 ppc64el
 Description: Official CouchDB Ubuntu 20.04 focal repository
+
+Codename: jammy
+Components: main
+Architectures: amd64 arm64 ppc64el
+Description: Official CouchDB Ubuntu 22.04 jammy repository


### PR DESCRIPTION
In the couchdb-ci used this to create the image
```
ERLANGVERSION=default ./build.sh buildx-platform ubuntu-jammy
```

There was an error building erlang from source with included openssl 3.x so opted to use the built-in default erlang 24 there.

To build the image then used that image to build the jammy 3.2.2-2 deb
package with:

```
ERLANGVERSION=default ./build.sh couch ubuntu-jammy apache-couchdb-3.2.2.tar.gz
./build.sh couch-upload-all
```
