### PR TITLE
Document the need to set couchdb/cookie

### DIFF
--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -59,6 +59,8 @@ bound to 127.0.0.1, and set an admin password of "password":
 COUCHDB_PASSWORD=password
 echo "couchdb couchdb/mode select standalone
 couchdb couchdb/mode seen true
+couchdb couchdb/cookie string elmo
+couchdb couchdb/cookie seen true
 couchdb couchdb/bindaddress string 127.0.0.1
 couchdb couchdb/bindaddress seen true
 couchdb couchdb/adminpass password ${COUCHDB_PASSWORD}

--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -56,10 +56,11 @@ mode.
 The following commands will install CouchDB in standalone mode,
 bound to 127.0.0.1, and set an admin password of "password":
 
+COUCHDB_COOKIE=$(openssl rand -hex 32)
 COUCHDB_PASSWORD=password
 echo "couchdb couchdb/mode select standalone
 couchdb couchdb/mode seen true
-couchdb couchdb/cookie string elmo
+couchdb couchdb/cookie string ${COUCHDB_COOKIE} 
 couchdb couchdb/cookie seen true
 couchdb couchdb/bindaddress string 127.0.0.1
 couchdb couchdb/bindaddress seen true
@@ -73,12 +74,14 @@ The following commands will install CouchDB in clustered mode,
 bound to all interfaces, and set the Erlang nodename, cookie, and
 admin password:
 
+# Note: The same cookie should be used for all nodes in the couchdb cluster
+COUCHDB_COOKIE=$(openssl rand -hex 32)
 COUCHDB_PASSWORD=password
 echo "couchdb couchdb/mode select clustered
 couchdb couchdb/mode seen true
 couchdb couchdb/nodename string couchdb@machine.domain.com
 couchdb couchdb/nodename seen true
-couchdb couchdb/cookie string elmo
+couchdb couchdb/cookie string ${COUCHDB_COOKIE} 
 couchdb couchdb/cookie seen true
 couchdb couchdb/bindaddress string 0.0.0.0
 couchdb couchdb/bindaddress seen true


### PR DESCRIPTION
## Overview

It looks like the [results of this issue ](https://github.com/apache/couchdb/issues/4001#issuecomment-1104720084)did not make it into the docs.
This lead to some weeping and gnashing of teeth while trying to do an UN-attended install on a ubuntu vm 😄 

Happy holidays! 👋🏽  🎉 

## Testing recommendations

- Create Ubuntu VM on digital ocean for example (this was tested on 22.04)
- Log in and run these commands
```
# https://docs.couchdb.org/en/3.2.2-docs/install/unix.html
curl --silent https://couchdb.apache.org/repo/keys.asc \
    | gpg --dearmor \
    | tee /usr/share/keyrings/couchdb-archive-keyring.gpg >/dev/null 2>&1

source /etc/os-release

echo "deb [signed-by=/usr/share/keyrings/couchdb-archive-keyring.gpg] https://apache.jfrog.io/artifactory/couchdb-deb/ ${VERSION_CODENAME} main" \
    | sudo tee /etc/apt/sources.list.d/couchdb.list >/dev/null


# https://github.com/apache/couchdb-pkg/blob/main/debian/README.Debian
echo "couchdb couchdb/mode select standalone
couchdb couchdb/mode seen true
couchdb couchdb/bindaddress string 127.0.0.1
couchdb couchdb/bindaddress seen true
couchdb couchdb/cookie string monkey
couchdb couchdb/cookie seen true
couchdb couchdb/adminpass password safepassword
couchdb couchdb/adminpass seen true
couchdb couchdb/adminpass_again password safepassword
couchdb couchdb/adminpass_again seen true" | debconf-set-selections

apt-get --yes -qq update
DEBIAN_FRONTEND=noninteractive apt-get --yes -qq install couchdb
```

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-pkg/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [x] Documentation reflects the changes;
