### PR TITLE
allow more characters in cookie

### DIFF
--- a/debian/couchdb.postinst
+++ b/debian/couchdb.postinst
@@ -159,13 +159,14 @@ case $1 in
 
     # Set the cookie
     db_get couchdb/cookie && cookie="$RET"
+    escaped_cookie=$(printf '%s' "$cookie" | sed 's:\\:\\\\:g')
 
     # change existing setcookie line if present
-    sed -i "s/^[# ]*-setcookie.*$/-setcookie ${cookie}/" /opt/couchdb/etc/vm.args
+    sed -i "/^[# ]*-setcookie/c\-setcookie '${escaped_cookie}'" /opt/couchdb/etc/vm.args
 
     # add setcookie line if not present
     if ! grep -q '^-setcookie' /opt/couchdb/etc/vm.args; then
-        echo "-setcookie ${cookie}" >> /opt/couchdb/etc/vm.args
+        printf -- '-setcookie %s\n' "'${cookie}'" >> /opt/couchdb/etc/vm.args
     fi
 
     # set inet_dist_use_interface default if not present
@@ -192,7 +193,7 @@ case $1 in
       clustered)
         db_get couchdb/nodename && nodename="$RET"
 
-        sed -i "s/^-name .*$/-name ${nodename}/" /opt/couchdb/etc/vm.args
+        sed -i "/^-name/c\-name ${nodename}" /opt/couchdb/etc/vm.args
 
         setbindaddress
 

--- a/rpm/SPECS/couchdb.spec.in
+++ b/rpm/SPECS/couchdb.spec.in
@@ -153,7 +153,8 @@ if %{__grep} -q "^-setcookie monster$" /opt/%{name}/etc/vm.args; then
     echo "Generating random cookie value."
     cookie=$(dd if=/dev/random bs=1 count=38 status=none | base64 | tr -cd [:alnum:])
   fi
-  %{__sed} -i "s/^-setcookie monster.*$/-setcookie ${cookie}/" /opt/%{name}/etc/vm.args
+  escaped_cookie=$(printf '%s' "$cookie" | sed 's:\\:\\\\:g')
+  %{__sed} -i "/^-setcookie monster/c\-setcookie '${escaped_cookie}'" /opt/%{name}/etc/vm.args
 elif %{__grep} -q "^[# ]*-setcookie$" /opt/%{name}/etc/vm.args; then
   # -v is a bash 4.2+ feature
   if [[ -v COUCHDB_COOKIE ]]; then
@@ -163,7 +164,8 @@ elif %{__grep} -q "^[# ]*-setcookie$" /opt/%{name}/etc/vm.args; then
     echo "Generating random cookie value."
     cookie=$(dd if=/dev/random bs=1 count=38 status=none | base64 | tr -cd [:alnum:])
   fi
-  %{__sed} -i "s/^[# ]*-setcookie.*$/-setcookie ${cookie}/" /opt/%{name}/etc/vm.args
+  escaped_cookie=$(printf '%s' "$cookie" | sed 's:\\:\\\\:g')
+  %{__sed} -i "/^[# ]*-setcookie/c\-setcookie '${escaped_cookie}'" /opt/%{name}/etc/vm.args
 fi
 %{__chown} -R couchdb:couchdb /opt/%{name}
 %{__chmod} a+x /opt/%{name}/bin/*


### PR DESCRIPTION
A cookie value with a '/' in it caused a sed error during postinst;

```
sed: -e expression #1, char 53: unknown option to `s'
```

Instead of a sed substitution we use `/c` to replace the cookie line. this permits most characters to get through. we escape backslashes prior to interpreting them when constructing the sed line.

I applied the same change to nodename even though a / in node name would be an error, for consistency.
