### PR TITLE
Add s390x cpu support to RHEL 8/9 RPM packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,14 +171,13 @@ centos9: SPIDERMONKEY_DEV=mozjs78-devel
 centos9: SM_VER=78
 centos9: sm-ver-rpm make-rpmbuild centos
 
-# Rocky 8 is a CentOS 8 alias
-rocky-8: centos-8
-rocky-8.6: centos-8
-rocky-8.7: centos-8
-
-# Rocky 9 is a CentOS 9 alias
-rocky-9: centos-9
-# s390x RHEL clone 9 based
+# Almalinux 8 is a CentOS 8 alias
+almalinux-8: centos-8
+# Almalinux 9 is a CentOS 9 alias
+almalinux-9: centos-9
+# s390x RHEL 8 clone based
+s390x-centos-8: centos-8
+# s390x RHEL 9 clone based
 s390x-centos-9: centos-9
 
 # aarch64 RHEL-based

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,10 @@ ubuntu-jammy: SM_VER=78
 ubuntu-jammy: jammy
 jammy: debian
 
+s390x-ubuntu-jammy: ubuntu-jammy
+arm64-ubuntu-jammy: ubuntu-jammy
+ppc64le-ubuntu-jammy: ubuntu-jammy
+
 # RPM default
 centos: PKGDIR=../rpmbuild/RPMS/$(PKGARCH)
 centos: find-couch-dist link-couch-dist build-rpm copy-pkgs
@@ -177,8 +181,12 @@ almalinux-8: centos-8
 almalinux-9: centos-9
 # s390x RHEL 8 clone based
 s390x-centos-8: centos-8
+ppc64le-centos-8: centos-8
 # s390x RHEL 9 clone based
 s390x-centos-9: centos-9
+arm64-centos-9: PKGARCH=aarch64
+arm64-centos-9: centos-9
+ppc64le-centos-9: centos-9
 
 # aarch64 RHEL-based
 aarch64-rhel: DIST=rhel

--- a/Makefile
+++ b/Makefile
@@ -164,10 +164,22 @@ centos8: SPIDERMONKEY_DEV=mozjs60-devel
 centos8: SM_VER=60
 centos8: sm-ver-rpm make-rpmbuild centos
 
+centos-9: DIST=centos-9
+centos-9: centos9
+centos9: SPIDERMONKEY=mozjs78
+centos9: SPIDERMONKEY_DEV=mozjs78-devel
+centos9: SM_VER=78
+centos9: sm-ver-rpm make-rpmbuild centos
+
 # Rocky 8 is a CentOS 8 alias
 rocky-8: centos-8
 rocky-8.6: centos-8
 rocky-8.7: centos-8
+
+# Rocky 9 is a CentOS 9 alias
+rocky-9: centos-9
+# s390x RHEL clone 9 based
+s390x-centos-9: centos-9
 
 # aarch64 RHEL-based
 aarch64-rhel: DIST=rhel

--- a/build.sh
+++ b/build.sh
@@ -30,7 +30,7 @@ SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # TODO derive these by interrogating the couchdb-ci repo rather than hard coding the list
 DEBIANS="debian-buster debian-bullseye"
 UBUNTUS="ubuntu-bionic ubuntu-focal ubuntu-jammy"
-CENTOSES="centos-7 centos-8"
+CENTOSES="centos-7 centos-8 centos-9"
 XPLAT_BASES="debian-bullseye ubuntu-focal"
 XPLAT_ARCHES="arm64 ppc64le s390x"
 BINARY_API="https://apache.jfrog.io/artifactory"
@@ -112,6 +112,7 @@ build-all-couch() {
       CONTAINERARCH="${arch}" build-couch ${base}
     done
   done
+  CONTAINERARCH="s390x" build-couch centos-9
 }
 
 

--- a/build.sh
+++ b/build.sh
@@ -112,6 +112,7 @@ build-all-couch() {
       CONTAINERARCH="${arch}" build-couch ${base}
     done
   done
+  CONTAINERARCH="s390x" build-couch centos-8
   CONTAINERARCH="s390x" build-couch centos-9
 }
 

--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,7 @@ SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DEBIANS="debian-buster debian-bullseye"
 UBUNTUS="ubuntu-bionic ubuntu-focal ubuntu-jammy"
 CENTOSES="centos-7 centos-8 centos-9"
-XPLAT_BASES="debian-bullseye ubuntu-focal"
+XPLAT_BASES="debian-bullseye ubuntu-focal ubuntu-jammy centos-8 centos-9"
 XPLAT_ARCHES="arm64 ppc64le s390x"
 BINARY_API="https://apache.jfrog.io/artifactory"
 ERLANGVERSION=${ERLANGVERSION:-24.3.4.10}
@@ -109,11 +109,11 @@ build-all-couch() {
   done
   for base in $XPLAT_BASES; do
     for arch in $XPLAT_ARCHES; do
-      CONTAINERARCH="${arch}" build-couch ${base}
+      if [[ ${base} != "centos-8" ]] || [[ ${arch} != "arm64" ]]; then
+        CONTAINERARCH="${arch}" build-couch ${base}
+      fi
     done
   done
-  CONTAINERARCH="s390x" build-couch centos-8
-  CONTAINERARCH="s390x" build-couch centos-9
 }
 
 

--- a/build.sh
+++ b/build.sh
@@ -175,6 +175,12 @@ upload-couch() {
         RELPATH="${DIST}/${PKGARCH}/${fname}"
         SUFFIX=""
         binary-upload
+    elif [ ${DIST} == "el9" ]; then
+        # see https://github.com/apache/couchdb-pkg/issues/103
+        DIST="el9Server"
+        RELPATH="${DIST}/${PKGARCH}/${fname}"
+        SUFFIX=""
+        binary-upload
     fi
   done
   echo "Recalculating Debian repo metadata..."

--- a/rpm/SPECS/couchdb.spec.in
+++ b/rpm/SPECS/couchdb.spec.in
@@ -94,9 +94,6 @@ languages and environments.
 %define __os_install_post %{nil}
 
 %prep
-%ifarch aarch64
-%patch01 -p1
-%endif
 
 %build
 ./configure --spidermonkey-version=%SM_VER%

--- a/rpm/SPECS/couchdb.spec.in
+++ b/rpm/SPECS/couchdb.spec.in
@@ -28,8 +28,8 @@ Prefix:        %{prefix}
 Group:         Applications/Databases
 URL:           https://couchdb.apache.org/
 Vendor:        The Apache Software Foundation
-BuildArch:     x86_64 ppc64le aarch64
-ExclusiveArch: x86_64 ppc64le aarch64
+BuildArch:     x86_64 ppc64le aarch64 s390x
+ExclusiveArch: x86_64 ppc64le aarch64 s390x
 Exclusiveos:   linux
 Packager:      CouchDB Developers <dev@couchdb.apache.org>
 Patch1:        0001-build-with-sm68-on-aarch64.patch


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Since the multi-arch docker image `apache/couchdbci-centos:8-erlang-24.3.4.10` and `apache/couchdbci-centos:9-erlang-24.3.4.10` which include s390x cpu support have been published, this PR aims to  add s390x support to building RPM packages on RHEL 8/9 clones.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

https://docs.couchdb.org/en/stable/intro/tour.html

RHEL 8/9 RPM packages can be successfully built for x86_64 and s390x after applying the code change in this PR. The generated packages have been verified by installing them and running couchdb service on both arches.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
