### PR TITLE
Remove python3-sphinx debian dependency

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -20,8 +20,8 @@ Build-Depends: debhelper (>= 9),
                %SPIDERMONKEY_DEV%,
                lsb-release,
                po-debconf,
-               python3,
-               python3-sphinx
+               python3
+
 Homepage: http://couchdb.apache.org/
 
 Package: couchdb


### PR DESCRIPTION
We use a venv for it. We just need python3 to be present.

https://github.com/apache/couchdb/tree/main/src/docs#readme

Hopefully it should fix this package build issue in CI:

```
+ make

[2023-11-10T07:01:25.147Z] make `bin/detect-target.sh`

[2023-11-10T07:01:25.147Z] make[1]: Entering directory '/home/jenkins/workspace/kins-cm1_FullPlatformMatrix_main/buster/couchdb-pkg'

[2023-11-10T07:01:25.147Z] cp debian/control.in debian/control

[2023-11-10T07:01:25.147Z] sed -i 's/%SPIDERMONKEY%/libmozjs-60-0/g' debian/control

[2023-11-10T07:01:25.147Z] sed -i 's/%SPIDERMONKEY_DEV%/libmozjs-60-dev/g' debian/control

[2023-11-10T07:01:25.147Z] echo 'SM_VER = 60' > debian/sm_ver.mk

[2023-11-10T07:01:25.147Z] rm -rf /home/jenkins/workspace/kins-cm1_FullPlatformMatrix_main/buster/couchdb/apache-couchdb-3.3.2-5a21bb2/debian

[2023-11-10T07:01:25.147Z] cp -R debian /home/jenkins/workspace/kins-cm1_FullPlatformMatrix_main/buster/couchdb/apache-couchdb-3.3.2-5a21bb2

[2023-11-10T07:01:25.147Z] cd /home/jenkins/workspace/kins-cm1_FullPlatformMatrix_main/buster/couchdb/apache-couchdb-3.3.2-5a21bb2 && dch -v 3.3.2-5a21bb2~buster "Automatically generated package from upstream."

[2023-11-10T07:01:25.147Z] cd /home/jenkins/workspace/kins-cm1_FullPlatformMatrix_main/buster/couchdb/apache-couchdb-3.3.2-5a21bb2 && dpkg-buildpackage -b -us -uc

[2023-11-10T07:01:25.496Z] dpkg-buildpackage: info: source package couchdb

[2023-11-10T07:01:25.496Z] dpkg-buildpackage: info: source version 3.3.2-5a21bb2~buster

[2023-11-10T07:01:25.496Z] dpkg-buildpackage: info: source distribution UNRELEASED

[2023-11-10T07:01:25.496Z] dpkg-buildpackage: info: source changed by "CouchDB Developers" <"dev@couchdb.apache.org">

[2023-11-10T07:01:25.496Z]  dpkg-source --before-build .

[2023-11-10T07:01:25.496Z] dpkg-buildpackage: info: host architecture amd64

[2023-11-10T07:01:25.496Z] dpkg-source: info: using options from apache-couchdb-3.3.2-5a21bb2/debian/source/options: --compression=bzip2 --compression-level=9

[2023-11-10T07:01:25.844Z] dpkg-checkbuilddeps: error: Unmet build dependencies: python3-sphinx

[2023-11-10T07:01:25.844Z] dpkg-buildpackage: warning: build dependencies/conflicts unsatisfied; aborting

[2023-11-10T07:01:25.844Z] dpkg-buildpackage: warning: (Use -d flag to override.)

[2023-11-10T07:01:25.844Z] make[1]: *** [Makefile:241: dpkg] Error 3

[2023-11-10T07:01:25.844Z] make[1]: Leaving directory '/home/jenkins/workspace/kins-cm1_FullPlatformMatrix_main/buster/couchdb-pkg'

[2023-11-10T07:01:25.844Z] make: *** [Makefile:41: all] Error 2
```