### PR TITLE
Remove empty line from debian control.in

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -21,7 +21,6 @@ Build-Depends: debhelper (>= 9),
                lsb-release,
                po-debconf,
                python3
-
 Homepage: http://couchdb.apache.org/
 
 Package: couchdb


### PR DESCRIPTION
Attempt to fix:
```
[2023-11-10T17:11:57.735Z] cd /home/jenkins/workspace/kins-cm1_FullPlatformMatrix_main/bullseye/couchdb/apache-couchdb-3.3.2-5a21bb2 && dpkg-buildpackage -b -us -uc
[2023-11-10T17:11:57.735Z] dpkg-buildpackage: error: syntax error in debian/control at line 26: block lacks the 'Package' field
[2023-11-10T17:11:57.735Z] make[1]: *** [Makefile:241: dpkg] Error 25
[2023-11-10T17:11:57.735Z] make[1]: Leaving directory '/home/jenkins/workspace/kins-cm1_FullPlatformMatrix_main/bullseye/couchdb-pkg'
```

From https://www.debian.org/doc/debian-policy/ch-controlfields.html#syntax-of-control-files it seems empty lines are significant:
> A control file consists of one or more stanzas of fields. [2](https://www.debian.org/doc/debian-policy/ch-controlfields.html#id17) The stanzas are separated by empty lines.
