### PR TITLE
Build and include Nouveau if it's present in the tarball

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -22,7 +22,11 @@ override_dh_auto_clean:
 	-mv src/mango/src/mango_cursor_text.nocompile src/mango/src/mango_cursor_text.erl
 
 override_dh_auto_configure:
-	./configure --spidermonkey-version $(SM_VER)
+	if [ -d "./nouveau" ]; then \
+		./configure --spidermonkey-version $(SM_VER) --enable-nouveau; \
+        else \
+		./configure --spidermonkey-version $(SM_VER); \
+	fi
 
 override_dh_auto_build:
 	dh_auto_build -- release

--- a/rpm/SPECS/couchdb.spec.in
+++ b/rpm/SPECS/couchdb.spec.in
@@ -96,7 +96,11 @@ languages and environments.
 %prep
 
 %build
-./configure --spidermonkey-version=%SM_VER%
+if [ -d ./nouveau ]; then
+    ./configure --spidermonkey-version=%SM_VER% --enable-nouveau
+else
+    ./configure --spidermonkey-version=%SM_VER%
+fi
 %{__make} release
 
 %clean


### PR DESCRIPTION
We want to be able to build older patch release packages as well as the new releases with Nouveau. To keep it simple we just inspect the presence of the nouveau directory.

Issue: https://github.com/apache/couchdb/issues/4859
