### PR TITLE
Update default Erlang version to 24.3.4.15

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ CENTOSES="centos-7 centos-8 centos-9"
 XPLAT_BASES="debian-bullseye debian-bookworm ubuntu-focal ubuntu-jammy centos-8 centos-9"
 XPLAT_ARCHES="arm64 ppc64le s390x"
 BINARY_API="https://apache.jfrog.io/artifactory"
-ERLANGVERSION=${ERLANGVERSION:-24.3.4.14}
+ERLANGVERSION=${ERLANGVERSION:-24.3.4.15}
 
 split-os-ver() {
   OLDIFS=$IFS


### PR DESCRIPTION
Packages are already updated. This is updating the default in the build.sh script.
