### PR TITLE
Fix snap unset

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -23,7 +23,7 @@ _modify_vm_args() {
   value="$2"
   replace_line="-$opt $value"
   if $(grep -q "^# -$opt" $VM_ARGS); then
-    sed --in-place "s/^#-$opt .*/$replace_line/" $VM_ARGS
+    sed --in-place "s/^#-$opt.*/$replace_line/" $VM_ARGS
   elif $(grep -q "^-$opt " $VM_ARGS); then
     sed --in-place "s/^-$opt .*/$replace_line/" $VM_ARGS
   else

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -23,7 +23,7 @@ _modify_vm_args() {
   value="$2"
   replace_line="-$opt $value"
   if $(grep -q "^# -$opt" $VM_ARGS); then
-    sed --in-place "s/^#-$opt.*/$replace_line/" $VM_ARGS
+    sed --in-place "s/^# -$opt.*/$replace_line/" $VM_ARGS
   elif $(grep -q "^-$opt " $VM_ARGS); then
     sed --in-place "s/^-$opt .*/$replace_line/" $VM_ARGS
   else

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -22,11 +22,14 @@ _modify_vm_args() {
   opt=$1
   value="$2"
   replace_line="-$opt $value"
-  if $(grep -q "^[#|[:space:]]*-$opt " $VM_ARGS); then
-    sed --in-place "s/^[#|[:space:]]*-$opt .*/$replace_line/" $VM_ARGS 
+  if $(grep -q "^# -$opt" $VM_ARGS); then
+    sed --in-place "s/^#-$opt .*/$replace_line/" $VM_ARGS
+  elif $(grep -q "^-$opt " $VM_ARGS); then
+    sed --in-place "s/^-$opt .*/$replace_line/" $VM_ARGS
   else
     echo $replace_line >> $VM_ARGS
   fi
+  snapctl unset $key
 }
 
 ## add or replace for the local.ini file
@@ -39,6 +42,7 @@ _modify_ini_args() {
   else
     echo $replace_line >> $LOCAL_INI
   fi
+  snapctl unset $key
 }
 
 # The vm_args file can only be changed from the filesystem

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -29,7 +29,6 @@ _modify_vm_args() {
   else
     echo $replace_line >> $VM_ARGS
   fi
-  snapctl unset $key
 }
 
 ## add or replace for the local.ini file
@@ -42,7 +41,6 @@ _modify_ini_args() {
   else
     echo $replace_line >> $LOCAL_INI
   fi
-  snapctl unset $key
 }
 
 # The vm_args file can only be changed from the filesystem
@@ -55,6 +53,7 @@ do
   if [ ! -z "$val" ]; then
     _modify_vm_args $key $val
     sleep 0.125
+    snapctl unset $key
   fi
 done
 
@@ -65,5 +64,6 @@ do
   if [ ! -z "$val" ]; then
     _modify_ini_args $key $val
     sleep 0.125
+    snapctl unset $key
   fi
 done


### PR DESCRIPTION
## Overview

snap `set couchdb name=xxxx` corrupts vm.args.

Since needing to handle `# - setcookie` the commented `# -name=examples` are also caught by regex.

## Testing recommendations

Tested twice with when `vm.args`

`# -cookie` 
`-cookie xxxx`

`sudo snap set couchdb-sklassen setcookie=cutter` 
`sudo snap set couchdb-sklassen name=couchdb1@127.0.0.1`

## Related Pull Requests

Handle the commented and not commented vm.arg changes separately.

I have also unset the variables after config changes. This speeds up `snap set` as previously set variables
no longer requires changing the file a second time. 

## Checklist

- [ X ] Code is written and works correctly;
- [ X] Changes are covered by tests;
- [ NA ] Documentation reflects the changes;
