### PR TITLE
Update supported OSes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,30 +43,6 @@ all:
 # Debian default
 debian: sm-ver-debian find-couch-dist copy-debian update-changelog dpkg lintian copy-pkgs
 
-# Debian 10 - buster
-debian-buster: PLATFORM=buster
-debian-buster: DIST=debian-buster
-debian-buster: SPIDERMONKEY=libmozjs-60-0
-debian-buster: SPIDERMONKEY_DEV=libmozjs-60-dev
-debian-buster: SM_VER=60
-debian-buster: buster
-
-# Blacklist arm64 from SM60 for now.
-# See https://github.com/apache/couchdb/issues/2423 for details.
-arm64v8-debian-buster: aarch64-debian-buster
-aarch64-debian-buster: PLATFORM=buster
-aarch64-debian-buster: DIST=debian-buster
-aarch64-debian-buster: buster
-
-ppc64le-debian-buster: PLATFORM=buster
-ppc64le-debian-buster: DIST=debian-buster
-ppc64le-debian-buster: SPIDERMONKEY=libmozjs-60-0
-ppc64le-debian-buster: SPIDERMONKEY_DEV=libmozjs-60-dev
-ppc64le-debian-buster: SM_VER=60
-ppc64le-debian-buster: buster
-
-buster: debian
-
 # Debian 11 - bullseye
 debian-bullseye: PLATFORM=bullseye
 debian-bullseye: DIST=debian-bullseye
@@ -135,12 +111,6 @@ s390x-debian-bookworm: bookworm
 
 bookworm: debian
 
-# Ubuntu 18.04 (Bionic)
-ubuntu-bionic: PLATFORM=bionic
-ubuntu-bionic: DIST=ubuntu-bionic
-ubuntu-bionic: bionic
-bionic: debian
-
 # Ubuntu 20.04 (Focal)
 ubuntu-focal: PLATFORM=focal
 ubuntu-focal: DIST=ubuntu-focal
@@ -188,12 +158,6 @@ ppc64le-ubuntu-jammy: ubuntu-jammy
 centos: PKGDIR=../rpmbuild/RPMS/$(PKGARCH)
 centos: find-couch-dist link-couch-dist build-rpm copy-pkgs
 
-centos-7: DIST=centos-7
-centos-7: centos7
-centos7: SPIDERMONKEY=couch-js = 1:1.8.5
-centos7: SPIDERMONKEY_DEV=couch-js-devel = 1:1.8.5
-centos7: sm-ver-rpm make-rpmbuild centos
-
 centos-8: DIST=centos-8
 centos-8: centos8
 centos8: SPIDERMONKEY=mozjs60
@@ -215,6 +179,7 @@ almalinux-8.9: centos-8
 # Almalinux 9 is a CentOS 9 alias
 almalinux-9: centos-9
 almalinux-9.2: centos-9
+almalinux-9.4: centos-9
 # s390x RHEL 8 clone based
 s390x-centos-8: centos-8
 ppc64le-centos-8: centos-8
@@ -231,9 +196,6 @@ aarch64-rhel: SPIDERMONKEY=couch-js-68
 aarch64-rhel: SPIDERMONKEY_DEV=couch-js-68-devel
 aarch64-rhel: SM_VER=68
 aarch64-rhel: sm-ver-rpm make-rpmbuild centos
-
-openSUSE: centos7
-
 
 # ######################################
 get-couch:

--- a/build.sh
+++ b/build.sh
@@ -28,9 +28,9 @@ set -e
 SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # TODO derive these by interrogating the couchdb-ci repo rather than hard coding the list
-DEBIANS="debian-buster debian-bullseye debian-bookworm"
-UBUNTUS="ubuntu-bionic ubuntu-focal ubuntu-jammy"
-CENTOSES="centos-7 centos-8 centos-9"
+DEBIANS="debian-bullseye debian-bookworm"
+UBUNTUS="ubuntu-focal ubuntu-jammy"
+CENTOSES="centos-8 centos-9"
 XPLAT_BASES="debian-bullseye debian-bookworm ubuntu-focal ubuntu-jammy centos-8 centos-9"
 XPLAT_ARCHES="arm64 ppc64le s390x"
 BINARY_API="https://apache.jfrog.io/artifactory"
@@ -163,13 +163,7 @@ upload-couch() {
     RELPATH="${DIST}/${PKGARCH}/${fname}"
     SUFFIX=""
     binary-upload
-    if [ ${DIST} == "el7" ]; then
-        # see https://github.com/apache/couchdb-pkg/issues/103
-        DIST="el7Server"
-        RELPATH="${DIST}/${PKGARCH}/${fname}"
-        SUFFIX=""
-        binary-upload
-    elif [ ${DIST} == "el8" ]; then
+    if [ ${DIST} == "el8" ]; then
         # see https://github.com/apache/couchdb-pkg/issues/103
         DIST="el8Server"
         RELPATH="${DIST}/${PKGARCH}/${fname}"

--- a/repo/conf/distributions
+++ b/repo/conf/distributions
@@ -1,18 +1,3 @@
-Codename: jessie
-Components: main
-Architectures: amd64 arm64 ppc64el
-Description: Official CouchDB Debian jessie repository
-
-Codename: stretch
-Components: main
-Architectures: amd64 arm64 ppc64el
-Description: Official CouchDB Debian stretch repository
-
-Codename: buster
-Components: main
-Architectures: amd64 arm64 ppc64el
-Description: Official CouchDB Debian buster repository
-
 Codename: bullseye
 Components: main
 Architectures: amd64 arm64 ppc64el
@@ -22,16 +7,6 @@ Codename: bookworm
 Components: main
 Architectures: amd64 arm64 ppc64el
 Description: Official CouchDB Debian bookworm repository
-
-Codename: xenial
-Components: main
-Architectures: amd64 arm64 ppc64el
-Description: Official CouchDB Ubuntu 16.04 xenial repository
-
-Codename: bionic
-Components: main
-Architectures: amd64 arm64 ppc64el
-Description: Official CouchDB Ubuntu 18.04 bionic repository
 
 Codename: focal
 Components: main


### PR DESCRIPTION
Remove centos 7, bionic and buster.

Also some left-over jessie and stretch references.

Latest "CentOS" 9 is Almalinux 9.4 so add it to the makefile ruleset.
