### PR TITLE
Add Almalinux 8.10 target to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,8 @@ centos9: sm-ver-rpm make-rpmbuild centos
 almalinux-8: centos-8
 almalinux-8.8: centos-8
 almalinux-8.9: centos-8
+almalinux-8.10: centos-8
+
 # Almalinux 9 is a CentOS 9 alias
 almalinux-9: centos-9
 almalinux-9.2: centos-9


### PR DESCRIPTION
To fix full CI error
```
[2024-06-06T17:36:45.310Z] + make
[2024-06-06T17:36:45.310Z] make `bin/detect-target.sh`
[2024-06-06T17:36:45.372Z] make[1]: Entering directory '/home/jenkins/workspace/ormMatrix_jenkins-otp-25-minimum/centos8/couchdb-pkg'
[2024-06-06T17:36:45.372Z] make[1]: *** No rule to make target 'almalinux-8.10'.  Stop.
```
