### PR TITLE
Fix Makefile for js68 rpm builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,6 @@ couch-js-rpms: couch-js-clean
 
 couch-js-68-rpms: couch-js-clean
 	mkdir -p ../rpmbuild
-	cp -R js68/* ../rpmbuild
+	cp -R js68/rpm/* ../rpmbuild
 	cd ../rpmbuild/SOURCES && curl -O https://ftp.mozilla.org/pub/firefox/releases/68.12.0esr/source/firefox-68.12.0esr.source.tar.xz
 	cd ../rpmbuild && rpmbuild --verbose -bb SPECS/js68.spec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CouchDB Packaging support repo
 
-The main purpose of this repository is to provide packaging support files for Apache CouchDB and its SpiderMoneky 1.8.5 dependency, for a number of well-known and used packaging formats, namely:
+The main purpose of this repository is to provide packaging support files for Apache CouchDB and its SpiderMonkey 1.8.5 dependency, for a number of well-known and used packaging formats, namely:
 
 * `.deb` files, as used by Debian, Ubuntu, and derivatives
 * `.rpm` files, as used by CentOS, RedHat, and derivatives


### PR DESCRIPTION
## Overview

Noticed on an el8 machine that the Makefile was not copying folders over properly from js68/rpm/ and instead putting an rpm folder in rpmbuild, where there should have been SOURCES and SPECS. This led to the steps afterwards failing.

This PR fixes that issue, as well as a typo in the readme

## Testing recommendations

Attempt to build the rpms for js68 via the makefile
`make couch-js-68-rpms`

## Checklist

- [x] Code is written and works correctly;
- [N/A] Changes are covered by tests;
- [N/A] Documentation reflects the changes;
