### PR TITLE
Exclude PPC64LE arch for packaging

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -109,7 +109,18 @@ build-all-couch() {
   done
   for base in $XPLAT_BASES; do
     for arch in $XPLAT_ARCHES; do
-      if [[ ${base} != "centos-8" ]] || [[ ${arch} != "arm64" ]]; then
+      # nouveau packaging fails on ppc64le OSes
+      # see https://github.com/apache/couchdb-pkg/issues/140
+      echo " **** base:${base}  arch:${arch} ****"
+      if ! [[
+              ( ${base} == "centos-8" && ${arch} == "arm64" ) ||
+              ( ${base} == "centos-8" && ${arch} == "ppc64le" ) ||
+              ( ${base} == "centos-9" && ${arch} == "ppc64le" ) ||
+              ( ${base} == "debian-bullseye" && ${arch} == "ppc64le" ) ||
+              ( ${base} == "debian-bookworm" && ${arch} == "ppc64le" ) ||
+              ( ${base} == "ubuntu-focal" && ${arch} == "ppc64le" ) ||
+              ( ${base} == "ubuntu-jammy" && ${arch} == "ppc64le" )
+      ]]; then
         CONTAINERARCH="${arch}" build-couch ${base}
       fi
     done


### PR DESCRIPTION
There is an `Unknown privilege violation (03)` error emitted to the log followed by a register dump right before gradle does it's download. Then everything seems to continue as normal, but suddenly the linter fails. This happens on PPC64LE and it seems to work for other arches. So let's exclude the combination which fail for now.

See issue: https://github.com/apache/couchdb-pkg/issues/140
