### PR TITLE
No need to set log level to info

### DIFF
--- a/debian/10-filelog.ini
+++ b/debian/10-filelog.ini
@@ -1,4 +1,3 @@
 [log]
 writer = file
 file = /var/log/couchdb/couchdb.log
-level = info


### PR DESCRIPTION
That's the default anyway

```
> couch_log_config:get(report_level).
info
```

Also mentioned in the default.ini:

https://github.com/apache/couchdb/blob/d38f14f7d777b7cda79b9862ee304150ad3418ea/rel/overlay/etc/default.ini#L716
