### PR TITLE
Update nouveau rpm package startup script

### DIFF
--- a/rpm/SOURCES/couchdb-nouveau
+++ b/rpm/SOURCES/couchdb-nouveau
@@ -1,0 +1,16 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# alternatives system will automatically switch the /usr/lib/jvm/jre symlink
+
+JAVA_HOME="/usr/lib/jvm/jre"
+JAVA_OPTS="-server -Djava.awt.headless=true -Xmx2g"

--- a/rpm/SOURCES/couchdb-nouveau.service
+++ b/rpm/SOURCES/couchdb-nouveau.service
@@ -4,8 +4,8 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-Environment="JAVA_OPTS=-server"
-ExecStart=/opt/couchdb/nouveau/bin/nouveau server /opt/couchdb/etc/nouveau.yaml
+EnvironmentFile=/etc/sysconfig/couchdb-nouveau
+ExecStart=/bin/sh -c "exec ${JAVA_HOME}/bin/java ${JAVA_OPTS} -jar /opt/couchdb/nouveau/lib/nouveau-*.jar server /opt/couchdb/etc/nouveau.yaml"
 LimitNOFILE=infinity
 Restart=on-failure
 NoNewPrivileges=true

--- a/rpm/SPECS/couchdb.spec.in
+++ b/rpm/SPECS/couchdb.spec.in
@@ -22,6 +22,7 @@ Release:       1%{?dist}
 Source:        https://www.apache.org/dist/couchdb/source/${version}/apache-couchdb-%{version}.tar.gz
 Source1:       %{name}.service
 Source2:       %{name}-nouveau.service
+Source3:       %{name}-nouveau
 Prefix:        %{prefix}
 Group:         Applications/Databases
 URL:           https://couchdb.apache.org/
@@ -98,6 +99,7 @@ if ! /usr/bin/getent passwd couchdb > /dev/null; then /usr/sbin/adduser \
 /bin/find %{buildroot}/opt/%{name} -name *.ini -exec %{__chmod} 0640 {} \;
 %{__install} -Dp -m0644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
 %{__install} -Dp -m0644 %{SOURCE2} %{buildroot}%{_unitdir}/%{name}-nouveau.service
+%{__install} -Dp -m0644 %{SOURCE3} %{buildroot}/etc/sysconfig/%{name}-nouveau
 %{__ln_s} -f -T %{_sharedstatedir}/%{name} %{buildroot}/opt/%{name}/data
 
 %post
@@ -137,7 +139,6 @@ fi
 
 %{__chown} -R couchdb:couchdb /opt/%{name}
 %{__chmod} a+x /opt/%{name}/bin/*
-%{__chmod} a+x /opt/%{name}/nouveau/bin/*
 %systemd_post %{name}.service
 %systemd_post %{name}-nouveau.service
 
@@ -151,7 +152,7 @@ fi
 
 if [ $1 -eq 0 ] ; then
     # uninstall, remove auto-generated nouveau enable file
-    ${__rm} /opt/couchdb/etc/default.d/10-nouveau.ini
+    %{__rm} /opt/couchdb/etc/default.d/10-nouveau.ini
 fi
 
 %files
@@ -161,6 +162,7 @@ fi
 %config(noreplace) /opt/couchdb/etc/local.ini
 %config(noreplace) /opt/couchdb/etc/vm.args
 %config(noreplace) /opt/couchdb/etc/nouveau.yaml
+%config(noreplace) /etc/sysconfig/couchdb-nouveau
 %{_unitdir}/%{name}.service
 %{_unitdir}/%{name}-nouveau.service
 


### PR DESCRIPTION
This mostly matches the change in the deb package.

RPM servers use `/etc/sysconfig` instead of `/etc/default`

While at it fix a typo in postun script: `${__rm}` -> `%{__rm}`
