### PR TITLE
Ensure nouveau jar files are owned by root

### DIFF
--- a/debian/couchdb-nouveau.postinst
+++ b/debian/couchdb-nouveau.postinst
@@ -36,8 +36,6 @@ case $1 in
         for i in "/opt/nouveau
           /opt/nouveau/etc
           /opt/nouveau/etc/nouveau.yaml
-          /opt/nouveau/lib
-          /opt/nouveau/lib/*.jar
           /var/lib/nouveau
           /var/lib/nouveau/*"
         do


### PR DESCRIPTION
Remove the nouveau jar files from the list of files to have their ownership and group changed in the couchdb-nouveau postinst script. These files are not expected to change at runtime, and the service should not have permission to overwrite them.

## Overview

The installed jar files should be owned as root to prevent them being overwritten, replaced or deleted accidentally, or maliciously in the event of a vulnerability in the service or its dependencies.

## Testing recommendations

Build and install packages with this change, observing that /opt/nouveau/lib and files within are owned by root.
The service should still operate correctly.

## GitHub issue number

n/a

## Related Pull Requests

none

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
