### PR TITLE
set JAVA_PATH in /etc/default/couchdb-nouveau

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -62,7 +62,7 @@ Package: couchdb-nouveau
 Architecture: any
 Depends: adduser,
          debconf,
-         default-jre-headless, java11-runtime-headless | java11-runtime,
+         java11-runtime-headless | java11-runtime,
          init-system-helpers,
          lsb-base,
          procps,

--- a/debian/couchdb-nouveau.default
+++ b/debian/couchdb-nouveau.default
@@ -12,5 +12,5 @@
 
 # Java options
 
-JAVA_HOME=/usr/lib/jvm/default-java
+JAVA_PATH=/usr/bin/java
 JAVA_OPTS="-server -Djava.awt.headless=true -Xmx2g"

--- a/debian/couchdb-nouveau.service
+++ b/debian/couchdb-nouveau.service
@@ -10,7 +10,7 @@ WorkingDirectory=/opt/nouveau
 EnvironmentFile=/etc/default/couchdb-nouveau
 
 # Lifecycle
-ExecStart=/bin/sh -c "exec ${JAVA_HOME}/bin/java ${JAVA_OPTS} -jar /opt/nouveau/lib/nouveau-*.jar server /opt/nouveau/etc/nouveau.yaml"
+ExecStart=/bin/sh -c "exec ${JAVA_PATH} ${JAVA_OPTS} -jar /opt/nouveau/lib/nouveau-*.jar server /opt/nouveau/etc/nouveau.yaml"
 SuccessExitStatus=143
 LimitNOFILE=infinity
 Restart=on-failure


### PR DESCRIPTION
The previous approach, cribbed from apacheds upstream package, forced an install of an undesired JRE.

Instead, just require something that is at least Java 11 (minimum for Lucene/Dropwizard) and point to /usr/bin/java. Admins can override cleanly in the defaults file if they have preferred JDK/JRE's at other paths.