### PR TITLE
Sync rpm nouveau java path usage with deb packages

### DIFF
--- a/rpm/SOURCES/couchdb-nouveau
+++ b/rpm/SOURCES/couchdb-nouveau
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# alternatives system will automatically switch the /usr/lib/jvm/jre symlink
+# alternatives system will automatically switch the /usr/bin/java
 
-JAVA_HOME="/usr/lib/jvm/jre"
+JAVA_PATH="/usr/bin/java"
 JAVA_OPTS="-server -Djava.awt.headless=true -Xmx2g"

--- a/rpm/SOURCES/couchdb-nouveau.service
+++ b/rpm/SOURCES/couchdb-nouveau.service
@@ -5,7 +5,7 @@ After=network-online.target
 
 [Service]
 EnvironmentFile=/etc/sysconfig/couchdb-nouveau
-ExecStart=/bin/sh -c "exec ${JAVA_HOME}/bin/java ${JAVA_OPTS} -jar /opt/couchdb/nouveau/lib/nouveau-*.jar server /opt/couchdb/etc/nouveau.yaml"
+ExecStart=/bin/sh -c "exec ${JAVA_PATH} ${JAVA_OPTS} -jar /opt/couchdb/nouveau/lib/nouveau-*.jar server /opt/couchdb/etc/nouveau.yaml"
 LimitNOFILE=infinity
 Restart=on-failure
 NoNewPrivileges=true


### PR DESCRIPTION
The `alternatives` system will switch /usr/bin/java accordingly

Reference: https://github.com/apache/couchdb-pkg/pull/156
