### PR TITLE
CouchDB 3.4.1 snap

### DIFF
--- a/README-SNAP.md
+++ b/README-SNAP.md
@@ -263,6 +263,20 @@ The backup database has a single shard and single directory:
 ```bash
   $ ls /var/snap/couchdb_bkup/common/data/shards/
 ```
+-----
+
+# Weather Report
+
+To run the weatherreport, you'll need to pass the configuration directory. The configuration directory
+needs to contain both the default.ini (which can be blank) and the local.ini. 
+
+For the weatherreport options, call with `--help` to see usage. call with `--list` to see options. 
+The `-d info` is the mininal required log level to see results. 
+
+```bash
+  $ /snap/couchdb/current/bin/weatherreport -c /var/snap/couchdb/current/etc/ -d info memory_use
+['couchdb@127.0.0.1'] [info] Process is using 0.4% of available RAM, totalling 68524 KB of real memory.
+```
 
 -----
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -74,7 +74,7 @@ parts:
       source "$(pwd)/../../erl-iex/build/asdf.sh"
       
       # Configure, build and release CouchDB binaries
-      ./configure --spidermonkey-version "$SPIDERMONKEY_VERSION" --with-nouveau && make release && cp -r rel/couchdb/* $SNAPCRAFT_PART_INSTALL
+      ./configure --spidermonkey-version "$SPIDERMONKEY_VERSION" && make release && cp -r rel/couchdb/* $SNAPCRAFT_PART_INSTALL
       
       # Verifying that all is working
       #make check
@@ -88,13 +88,10 @@ parts:
       - libmozjs-91-dev
       # For Fauxton
       - npm
-      # Nouveau
-      - openjdk-21-jdk-headless
     stage-packages:
       - libicu70
       - libssl3
       - libmozjs-91-0
-      - openjdk-21-jre-headless
     stage:
       - -usr/share/doc
       - -usr/share/man

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,7 @@
 #   under the License.
 ---
 name: couchdb
-version: 3.3.3
+version: 3.4.1
 type: app
 base: core22
 license: Apache-2.0
@@ -41,10 +41,10 @@ parts:
   erl-iex:
     plugin: dump
     build-environment:
-      - ASDF_ERLANG_VERSION: "24.3.4.17"
-      - ASDF_ELIXIR_VERSION: "1.15.7-otp-24"
+      - ASDF_ERLANG_VERSION: "25.2.3.13"
+      - ASDF_ELIXIR_VERSION: "1.15.8-otp-25"
     source: https://github.com/asdf-vm/asdf.git
-    source-branch: v0.13.1
+    source-branch: v0.14.1
     source-type: git
     build-packages:
       - libncurses-dev
@@ -67,14 +67,14 @@ parts:
     plugin: make
     build-environment:
       - SPIDERMONKEY_VERSION: "91"
-    source: https://dlcdn.apache.org/couchdb/source/3.3.3/apache-couchdb-3.3.3.tar.gz
+    source: https://dlcdn.apache.org/couchdb/source/3.4.1/apache-couchdb-3.4.1.tar.gz
     source-type: tar
     override-build: |
       # Use the version of erlang/elixir we configured before
       source "$(pwd)/../../erl-iex/build/asdf.sh"
       
       # Configure, build and release CouchDB binaries
-      ./configure --spidermonkey-version "$SPIDERMONKEY_VERSION" && make release && cp -r rel/couchdb/* $SNAPCRAFT_PART_INSTALL
+      ./configure --spidermonkey-version "$SPIDERMONKEY_VERSION" --with-nouveau && make release && cp -r rel/couchdb/* $SNAPCRAFT_PART_INSTALL
       
       # Verifying that all is working
       #make check

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -86,8 +86,6 @@ parts:
       - libssl-dev
       # Mozilla JS engine
       - libmozjs-91-dev
-      # For Fauxton
-      - npm
     stage-packages:
       - libicu70
       - libssl3

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,7 +41,7 @@ parts:
   erl-iex:
     plugin: dump
     build-environment:
-      - ASDF_ERLANG_VERSION: "25.2.3.13"
+      - ASDF_ERLANG_VERSION: "25.3.2.13"
       - ASDF_ELIXIR_VERSION: "1.15.8-otp-25"
     source: https://github.com/asdf-vm/asdf.git
     source-branch: v0.14.1
@@ -88,10 +88,13 @@ parts:
       - libmozjs-91-dev
       # For Fauxton
       - npm
+      # Nouveau
+      - openjdk-21-jdk-headless
     stage-packages:
       - libicu70
       - libssl3
       - libmozjs-91-0
+      - openjdk-21-jre-headless
     stage:
       - -usr/share/doc
       - -usr/share/man


### PR DESCRIPTION
Use latest CouchDB v3.4.1 for the snap package.