### PR TITLE
Update snapcraft.yaml adding gradle 

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -78,6 +78,8 @@ parts:
       
       # Verifying that all is working
       #make check
+    build-snaps:
+      - gradle --classic
     build-packages:
       - gcc
       - g++


### PR DESCRIPTION
Add a build-snap stanza.

## Overview

This is to avoid snapcraft attempting to install gradle.jar from external site.

Still does not work with remote-build.

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [X] Documentation reflects the changes;
