### PR TITLE
Update README-SNAP.md Added section on weatherreport

### DIFF
--- a/README-SNAP.md
+++ b/README-SNAP.md
@@ -263,6 +263,20 @@ The backup database has a single shard and single directory:
 ```bash
   $ ls /var/snap/couchdb_bkup/common/data/shards/
 ```
+-----
+
+# Weather Report
+
+To run the weatherreport, you'll need to pass the configuration directory. The configuration directory
+needs to contain both the default.ini (which can be blank) and the local.ini. 
+
+For the weatherreport options, call with `--help` to see usage. call with `--list` to see options. 
+The `-d info` is the mininal required log level to see results. 
+
+```bash
+  $ /snap/couchdb/current/bin/weatherreport -c /var/snap/couchdb/current/etc/ -d info memory_use
+['couchdb@127.0.0.1'] [info] Process is using 0.4% of available RAM, totalling 68524 KB of real memory.
+```
 
 -----
 


### PR DESCRIPTION
Weatherreport under snap works, it just needs some extra parameters.

## Overview

Main issue is that default.ini is missing from the `/var/snap/couchd/current/etc`. But weatherreport also needs to know the configuration directory and the default message level `notice` only shows exceptions.

## Testing recommendations

Ran the bash example on a fresh snap installation.

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [X] Documentation reflects the changes;
