### PR TITLE
Update install -- adding default.ini

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -32,6 +32,11 @@ if [ ! -s ${SNAP_INSTANCE_DATA}/etc/vm.args ]; then
    cat ${SNAP}/etc/vm.args > ${SNAP_INSTANCE_DATA}/etc/vm.args
 fi
 
+DEFAULT_INI=$SNAP_INSTANCE_DATA/etc/default.ini
+if [ ! -s ${DEFAULT_INI} ]; then
+   cat ${SNAP}/etc/default.ini > ${DEFAULT_INI}
+fi
+
 LOCAL_INI=$SNAP_INSTANCE_DATA/etc/local.ini
 if [ ! -s ${LOCAL_INI} ]; then
    cat ${SNAP}/etc/local.ini > ${LOCAL_INI}

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -32,10 +32,7 @@ if [ ! -s ${SNAP_INSTANCE_DATA}/etc/vm.args ]; then
    cat ${SNAP}/etc/vm.args > ${SNAP_INSTANCE_DATA}/etc/vm.args
 fi
 
-DEFAULT_INI=$SNAP_INSTANCE_DATA/etc/default.ini
-if [ ! -s ${DEFAULT_INI} ]; then
-   cat ${SNAP}/etc/default.ini > ${DEFAULT_INI}
-fi
+cat ${SNAP}/etc/default.ini > $SNAP_INSTANCE_DATA/etc/default.ini
 
 LOCAL_INI=$SNAP_INSTANCE_DATA/etc/local.ini
 if [ ! -s ${LOCAL_INI} ]; then

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -32,6 +32,8 @@ if [ ! -s ${SNAP_INSTANCE_DATA}/etc/vm.args ]; then
    cat ${SNAP}/etc/vm.args > ${SNAP_INSTANCE_DATA}/etc/vm.args
 fi
 
+cat ${SNAP}/etc/default.ini > $SNAP_INSTANCE_DATA/etc/default.ini
+
 LOCAL_INI=$SNAP_INSTANCE_DATA/etc/local.ini
 if [ ! -s ${LOCAL_INI} ]; then
    cat ${SNAP}/etc/local.ini > ${LOCAL_INI}


### PR DESCRIPTION
For fresh installations, add the default.ini (needed by weatherreport).

## Overview

We have only been copying in local.ini and ignoring default.ini. Weatherreport fails if it can't see default.ini

## Testing recommendations

Test a new snap version from snap store.

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [X] Documentation reflects the changes;
