### PR TITLE
fix file/dir permissions for nouveau

### DIFF
--- a/debian/couchdb-nouveau.postinst
+++ b/debian/couchdb-nouveau.postinst
@@ -42,6 +42,10 @@ case $1 in
             chown nouveau:nouveau $i >/dev/null 2>&1 || true
         done
 
+        # These should also not be world readable or writable:
+        chmod 0640 /opt/nouveau/etc/nouveau.yaml
+        chmod 0750 /var/lib/nouveau
+
         db_input high couchdb-nouveau/enable || true
         db_go || true
         db_get couchdb-nouveau/enable || true


### PR DESCRIPTION
Fixes apache/couchdb#5427

## Overview

Make nouveau config and state dir not world-read-write-able

## Testing recommendations

N/A

## GitHub issue number

https://github.com/apache/couchdb/issues/5427

## Related Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
