### PR TITLE
Fix repeated single-quoting of vm.args values

### DIFF
--- a/debian/couchdb.config
+++ b/debian/couchdb.config
@@ -16,6 +16,7 @@ set -e
 . /usr/share/debconf/confmodule
 
 alias stripwhitespace="sed -e 's/^[[:blank:]]*//' -e 's/[[:blank:]]*$//'"
+alias stripquote="sed -e 's/^\x27*//' -e 's/\x27*$//'"
 
 if [ -n "$DEBIAN_SCRIPT_DEBUG" ]; then set -v -x; DEBIAN_SCRIPT_TRACE=1; fi
 ${DEBIAN_SCRIPT_TRACE:+ echo "#42#DEBUG# RUNNING $0 $*" 1>&2 }
@@ -82,8 +83,8 @@ promptcookie() {
 
 # if they exist, make current settings debconf's defaults
 if [ -e /opt/couchdb/etc/vm.args ] ; then
-  cookie="$(grep '^-setcookie' /opt/couchdb/etc/vm.args | cut -d ' ' -f 2 | stripwhitespace)"
-  nodename="$(grep '^-name' /opt/couchdb/etc/vm.args | cut -d ' ' -f 2 | stripwhitespace)"
+  cookie="$(grep '^-setcookie' /opt/couchdb/etc/vm.args | cut -d ' ' -f 2 | stripwhitespace | stripquote)"
+  nodename="$(grep '^-name' /opt/couchdb/etc/vm.args | cut -d ' ' -f 2 | stripwhitespace | stripquote)"
   if [ -n "$cookie" ]; then
       db_set couchdb/cookie "${cookie}"
   fi
@@ -92,7 +93,7 @@ if [ -e /opt/couchdb/etc/vm.args ] ; then
   fi
 fi
 if [ -e /opt/couchdb/etc/local.ini ]; then
-  addr=$(sed -n '/^\[chttpd\]/, /^\[/ {/bind_address = / s/.* =//p;}' /opt/couchdb/etc/local.ini | stripwhitespace)
+  addr=$(sed -n '/^\[chttpd\]/, /^\[/ {/bind_address = / s/.* =//p;}' /opt/couchdb/etc/local.ini | stripwhitespace | stripquote)
   if [ -n "$addr" ]; then
     bindaddress=$addr
     db_set couchdb/bindaddress "${bindaddress}"
@@ -101,7 +102,7 @@ fi
 # might be overridden by a local.d file
 if [ -d /opt/couchdb/etc/local.d ] && ls /opt/couchdb/etc/local.d/*.ini >/dev/null 2>&1; then
   for f in $(ls /opt/couchdb/etc/local.d/*.ini); do
-    addr=$(sed -n '/^\[chttpd\]/, /^\[/ {/bind_address = / s/.* =//p;}' $f | stripwhitespace)
+    addr=$(sed -n '/^\[chttpd\]/, /^\[/ {/bind_address = / s/.* =//p;}' $f | stripwhitespace | stripquote)
     if [ -n "$addr" ]; then
       bindaddress=$addr
       db_set couchdb/bindaddress "${bindaddress}"    

--- a/debian/couchdb.postinst
+++ b/debian/couchdb.postinst
@@ -193,7 +193,7 @@ case $1 in
       clustered)
         db_get couchdb/nodename && nodename="$RET"
 
-        sed -i "/^-name/c\-name ${nodename}" /opt/couchdb/etc/vm.args
+        sed -i "/^-name/c\-name '${nodename}'" /opt/couchdb/etc/vm.args
 
         setbindaddress
 


### PR DESCRIPTION
Previously, values which were parsed from vm.args retained their single quotes when db_set. Later on, in the postinst script, when we replace values in vm.args they got another layer of single quotes.

Fix: #178

