### PR TITLE
Fix wrong handling of bind_address in debian package

### DIFF
--- a/debian/couchdb.config
+++ b/debian/couchdb.config
@@ -92,17 +92,19 @@ if [ -e /opt/couchdb/etc/vm.args ] ; then
   fi
 fi
 if [ -e /opt/couchdb/etc/local.ini ]; then
-  if grep -q '^bind_address =' /opt/couchdb/etc/local.ini; then
-    bindaddress="$(grep '^bind_address' /opt/couchdb/etc/local.ini | cut -d ' ' -f 3 | stripwhitespace)"
+  addr=$(sed -n '/^\[chttpd\]/, /^\[/ {/bind_address = / s/.* =//p;}' /opt/couchdb/etc/local.ini | stripwhitespace)
+  if [ -n "$addr" ]; then
+    bindaddress=$addr
     db_set couchdb/bindaddress "${bindaddress}"
   fi
 fi
 # might be overridden by a local.d file
-if [ -d /opt/couchdb/etc/local.d -a ls /opt/couchdb/etc/local.d/*.ini >/dev/null 2>&1 ]; then
+if [ -d /opt/couchdb/etc/local.d ] && ls /opt/couchdb/etc/local.d/*.ini >/dev/null 2>&1; then
   for f in $(ls /opt/couchdb/etc/local.d/*.ini); do
-    if grep -q '^bind_address =' $f; then
-      bindaddress="$(grep '^bind_address' $f | cut -d ' ' -f 3 | stripwhitespace)"
-      db_set couchdb/bindaddress "${bindaddress}"
+    addr=$(sed -n '/^\[chttpd\]/, /^\[/ {/bind_address = / s/.* =//p;}' $f | stripwhitespace)
+    if [ -n "$addr" ]; then
+      bindaddress=$addr
+      db_set couchdb/bindaddress "${bindaddress}"    
     fi
   done
 fi


### PR DESCRIPTION
## Overview

**The Debain Packages don't handle the bind_address correct while updating.**

**Problem 1:** If there is more than one bind_address in the local.ini, for example one for chttpd and one for prometheus the configure step fails. Now only the bind_address of the [chttpd] block is used.

**Problem 2:** The config script also looked into all of the local.d/*.ini files. This didn't work because of a wrong if condition. The condition was changed, so that i correctly evaluates if config files exist.

## Testing recommendations

Install CouchDB and configure an bind_address in the chttpd block of the local.ini or any local.d/*.ini file. Also add a second block that also contains a bind_address to the same file. Then install CouchDB again (using dpkg -i as it allows to install the same version over and over)
The configure step of the package should not fail. 
If using `DEBCONF_DEBUG=developer dpkg -i` to install it should show the most relevant bind_address found:
```
debconf (developer): --> 0 127.0.0.3
Processing triggers for man-db (2.11.2-2) ...
```
This should be the bind_address from the alphabetical last ini file in local.d if it contains or the bind_address from local.ini if there are no further config files.

## GitHub issue number

Fixes #175 

## Related Pull Requests

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
