### PR TITLE
Remove buggy 10-nouveau.ini creation

### DIFF
--- a/debian/couchdb-nouveau.config
+++ b/debian/couchdb-nouveau.config
@@ -18,4 +18,3 @@ set -e
 
 db_input high couchdb-nouveau/enable || true
 db_go
-db_get couchdb-nouveau/enable

--- a/debian/couchdb-nouveau.templates
+++ b/debian/couchdb-nouveau.templates
@@ -3,12 +3,10 @@
 # Failure to do so will result in a rejected pull request.
 
 Template: couchdb-nouveau/enable
-Type: boolean
+Type: note
 Default: true
-_Description: Enable Nouveau in CouchDB (if installed)?
- Enables nouveau in local CouchDB, if it is installed. You
- will need to reload config or restart CouchDB for the change
- to take effect if it is already running.
+_Description: Enable Nouveau in CouchDB
+ Remember to set `[nouveau] enable = true` in CouchDB and reload.
 
 Template: couchdb-nouveau/postrm_remove_indexes
 Type: boolean


### PR DESCRIPTION
## Overview

In an effort to make nouveau easier to use the couchdb-nouveau package would attempt to reconfigure couchdb. However this fails if you install couchdb and couchdb-nouveau at the same time (and doing so is quite normal).

Remove this code. The sysadm can make the single `enable = true` configuration change themselves.

https://github.com/apache/couchdb-pkg/issues/154


## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-pkg/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
