### PR TITLE
Ignore comment lines when extracting bind_address from .ini files

### DIFF
--- a/debian/couchdb.config
+++ b/debian/couchdb.config
@@ -93,7 +93,7 @@ if [ -e /opt/couchdb/etc/vm.args ] ; then
   fi
 fi
 if [ -e /opt/couchdb/etc/local.ini ]; then
-  addr=$(sed -n '/^\[chttpd\]/, /^\[/ {/bind_address = / s/.* =//p;}' /opt/couchdb/etc/local.ini | stripwhitespace | stripquote)
+  addr=$(sed -n '/^\[chttpd\]/, /^\[/ { /^;/d; /bind_address =/ s/.*=//p; }' /opt/couchdb/etc/local.ini | stripwhitespace | stripquote)
   if [ -n "$addr" ]; then
     bindaddress=$addr
     db_set couchdb/bindaddress "${bindaddress}"
@@ -102,7 +102,7 @@ fi
 # might be overridden by a local.d file
 if [ -d /opt/couchdb/etc/local.d ] && ls /opt/couchdb/etc/local.d/*.ini >/dev/null 2>&1; then
   for f in $(ls /opt/couchdb/etc/local.d/*.ini); do
-    addr=$(sed -n '/^\[chttpd\]/, /^\[/ {/bind_address = / s/.* =//p;}' $f | stripwhitespace | stripquote)
+    addr=$(sed -n '/^\[chttpd\]/, /^\[/ { /^;/d; /bind_address =/ s/.*=//p; }' $f | stripwhitespace | stripquote)
     if [ -n "$addr" ]; then
       bindaddress=$addr
       db_set couchdb/bindaddress "${bindaddress}"    


### PR DESCRIPTION


<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

The current config script unexpectedly extracts multiple `bind_address` lines even if they are commented out.
So, the package configuration fails like so:

```
Setting up couchdb (3.4.3.1~jammy) ...
dpkg: error processing package couchdb (--configure):
 installed couchdb package post-installation script subprocess returned error exit status 30
Errors were encountered while processing:
 couchdb
```

For example, this `local.ini` causes the error:

```ini
[chttpd]
;port = 5984
;bind_address = 127.0.0.1
; Options for the MochiWeb HTTP server.
;server_options = [{backlog, 128}, {acceptor_pool_size, 16}]
; For more socket options, consult Erlang's module 'inet' man page.
;socket_options = [{recbuf, 262144}, {sndbuf, 262144}, {nodelay, true}]
require_valid_user = true
bind_address = 0.0.0.0
```

Because `$addr` gets two addresses:

```
127.0.0.1
0.0.0.0
```

Debug log:

```
❯ sudo DEBIAN_FRONTEND=readline DEBCONF_DEBUG=developer dpkg --configure couchdb
Setting up couchdb (3.4.3.1~jammy) ...
debconf (developer): frontend started
debconf (developer): frontend running, package name is couchdb
debconf (developer): starting /var/lib/dpkg/info/couchdb.config configure 3.4.2~jammy
debconf (developer): <-- SET couchdb/cookie cookie-monster
debconf (developer): --> 0 value set
debconf (developer): <-- SET couchdb/bindaddress 127.0.0.1
debconf (developer): --> 0 value set
debconf (developer): <-- 0.0.0.0
debconf (developer): --> 20 Unsupported command "0.0.0.0" (full line was "0.0.0.0") received from confmodule.
debconf (developer): <-- INPUT high couchdb/mode
debconf (developer): --> 30 question skipped
debconf (developer): <-- GO
debconf (developer): --> 0 ok
dpkg: error processing package couchdb (--configure):
 installed couchdb package post-installation script subprocess returned error exit status 128
Errors were encountered while processing:
 couchdb
```

This PR makes the script ignore lines starting with `;`.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-pkg/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
