### PR TITLE
Add package support for Ubuntu Resolute Raccoon (26.04)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,20 @@ arm64-ubuntu-noble: ubuntu-noble
 aarch64-ubuntu-noble: ubuntu-noble
 ppc64le-ubuntu-noble: ubuntu-noble
 
+# Ubuntu 26.04 (Resolute)
+ubuntu-resolute: PLATFORM=resolute
+ubuntu-resolute: DIST=ubuntu-resolute
+ubuntu-resolute: SPIDERMONKEY=libmozjs-128-0
+ubuntu-resolute: SPIDERMONKEY_DEV=libmozjs-128-dev
+ubuntu-resolute: SM_VER=128
+ubuntu-resolute: resolute
+resolute: debian
+
+s390x-ubuntu-resolute: ubuntu-resolute
+arm64-ubuntu-resolute: ubuntu-resolute
+aarch64-ubuntu-resolute: ubuntu-resolute
+ppc64le-ubuntu-resolute: ubuntu-resolute
+
 # RPM default
 centos: PKGDIR=../rpmbuild/RPMS/$(PKGARCH)
 centos: find-couch-dist link-couch-dist build-rpm copy-pkgs

--- a/build.sh
+++ b/build.sh
@@ -29,9 +29,9 @@ SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # TODO derive these by interrogating the couchdb-ci repo rather than hard coding the list
 DEBIANS="debian-bullseye debian-bookworm debian-trixie"
-UBUNTUS="ubuntu-jammy ubuntu-noble"
+UBUNTUS="ubuntu-jammy ubuntu-noble ubuntu-resolute"
 CENTOSES="centos-8 centos-9 centos-10"
-XPLAT_BASES="debian-bullseye debian-bookworm debian-trixie ubuntu-jammy ubuntu-noble centos-8 centos-9 centos-10"
+XPLAT_BASES="debian-bullseye debian-bookworm debian-trixie ubuntu-jammy ubuntu-noble ubuntu-resolute centos-8 centos-9 centos-10"
 XPLAT_ARCHES="arm64 ppc64le s390x"
 BINARY_API="https://apache.jfrog.io/artifactory"
 ERLANGVERSION=${ERLANGVERSION:-26.2.5.20}
@@ -124,7 +124,8 @@ build-all-couch() {
               ( ${base} == "debian-bookworm" && ${arch} == "ppc64le" ) ||
               ( ${base} == "debian-trixie" && ${arch} == "ppc64le" ) ||
               ( ${base} == "ubuntu-jammy" && ${arch} == "ppc64le" ) ||
-              ( ${base} == "ubuntu-noble" && ${arch} == "ppc64le" )
+              ( ${base} == "ubuntu-noble" && ${arch} == "ppc64le" ) ||
+              ( ${base} == "ubuntu-resolute" && ${arch} == "ppc64le" )
       ]]; then
         CONTAINERARCH="${arch}" build-couch ${base}
       fi

--- a/repo/conf/distributions
+++ b/repo/conf/distributions
@@ -22,3 +22,8 @@ Codename: noble
 Components: main
 Architectures: amd64 arm64 ppc64el
 Description: Official CouchDB Ubuntu 24.04 noble repository
+
+Codename: resolute
+Components: main
+Architectures: amd64 arm64 ppc64el
+Description: Official CouchDB Ubuntu 26.04 resolute repository


### PR DESCRIPTION
## Overview

Add packaging support for Ubuntu Resolute Raccoon (26.04)

## Checklist

- [x] Code is written and works correctly