### PR TITLE
Try to fix resolute package builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ DEBCHANGELOG="Automatically generated package from upstream."
 
 JS_DEBCHANGELOG="Automatically generated package from couchdb-ci repository."
 
-export DEBFULLNAME="CouchDB Developers"
-export DEBEMAIL="dev@couchdb.apache.org"
+export DEBFULLNAME=CouchDB Developers
+export DEBEMAIL=dev@couchdb.apache.org
 
 # Default package directory (over-written for RPM based builds)
 PKGDIR=$(COUCHDIR)


### PR DESCRIPTION
```
12:52:15  dpkg-buildpackage: error: cannot parse maintainer email address ""CouchDB Developers" <"dev@couchdb.apache.org">" from changelog entry
12:52:15  dpkg-buildpackage: info: source package couchdb
12:52:15  dpkg-buildpackage: info: source version 3.5.1-a13d517~resolute
12:52:15  dpkg-buildpackage: info: source distribution UNRELEASED
12:52:15  dpkg-buildpackage: info: source changed by "CouchDB Developers" <"dev@couchdb.apache.org">
12:52:15  make[1]: *** [Makefile:316: dpkg] Error 25
```
