### PR TITLE
add mincore to SystemCallFilter for nouveau

### DIFF
--- a/debian/couchdb-nouveau.service
+++ b/debian/couchdb-nouveau.service
@@ -22,7 +22,7 @@ ProtectHome=yes
 ProtectSystem=strict
 ReadWritePaths=/var/lib/nouveau/
 SystemCallErrorNumber=EPERM
-SystemCallFilter=@system-service
+SystemCallFilter=@system-service mincore
 User=nouveau
 
 [Install]


### PR DESCRIPTION
## Overview

Add permission to use mincore syscall for nouveau.

## Testing recommendations

Install via debian package and run nouveau queries

## GitHub issue number

N/A

## Related Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
