### PR TITLE
Add Almalinux 9.8 and 10.2 for package building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,7 @@ almalinux-9.4: centos-9
 almalinux-9.5: centos-9
 almalinux-9.6: centos-9
 almalinux-9.7: centos-9
+almalinux-9.8: centos-9
 aarch64-almalinux-9.4: PKGARCH=aarch64
 aarch64-almalinux-9.4: centos-9
 aarch64-almalinux-9.5: PKGARCH=aarch64
@@ -240,6 +241,8 @@ aarch64-almalinux-9.6: PKGARCH=aarch64
 aarch64-almalinux-9.6: centos-9
 aarch64-almalinux-9.7: PKGARCH=aarch64
 aarch64-almalinux-9.7: centos-9
+aarch64-almalinux-9.8: PKGARCH=aarch64
+aarch64-almalinux-9.8: centos-9
 aarch64-almalinux-9: PKGARCH=aarch64
 aarch64-almalinux-9: centos-9
 # s390x RHEL 8 clone based
@@ -255,10 +258,13 @@ ppc64le-centos-9: centos-9
 # Almalinux 10 is a CentOS 10 alias
 almalinux-10: centos-10
 almalinux-10.1: centos-10
+almalinux-10.2: centos-10
 aarch64-almalinux-10: PKGARCH=aarch64
 aarch64-almalinux-10: centos-10
 aarch64-almalinux-10.1: PKGARCH=aarch64
 aarch64-almalinux-10.1: centos-10
+aarch64-almalinux-10.2: PKGARCH=aarch64
+aarch64-almalinux-10.2: centos-10
 # s390x RHEL 10 clone based
 s390x-centos-10: centos-10
 ppc64le-centos-10: centos-10

--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ CENTOSES="centos-8 centos-9 centos-10"
 XPLAT_BASES="debian-bullseye debian-bookworm debian-trixie ubuntu-jammy ubuntu-noble ubuntu-resolute centos-8 centos-9 centos-10"
 XPLAT_ARCHES="arm64 ppc64le"
 BINARY_API="https://apache.jfrog.io/artifactory"
-ERLANGVERSION=${ERLANGVERSION:-26.2.5.20}
+ERLANGVERSION=${ERLANGVERSION:-27.3.4.13}
 REPO_NAME="couch-dev"
 
 split-os-ver() {


### PR DESCRIPTION
## Overview

There are new minor versions of Almalinux (9.8 and 10.2), so handle them for package building.

## Related Pull Requests

https://github.com/apache/couchdb/pull/6036
https://ci-couchdb.apache.org/job/jenkins-cm1/job/PullRequests/view/change-requests/job/PR-6036/2/stages/?selected-node=72

## Checklist

- [x] Code is written and works correctly;